### PR TITLE
New version of AWS SDK needs ETag header with hex encoded MD5

### DIFF
--- a/src/main/java/ninja/S3Controller.java
+++ b/src/main/java/ninja/S3Controller.java
@@ -17,6 +17,7 @@ import com.google.common.io.Files;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.bouncycastle.util.encoders.Hex;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -132,8 +133,8 @@ public class S3Controller implements Controller {
     /**
      * Dispatching method handling bucket specific calls without content (HEAD and DELETE)
      *
-     * @param ctx         the context describing the current request
-     * @param bucketName  name of the bucket of interest
+     * @param ctx        the context describing the current request
+     * @param bucketName name of the bucket of interest
      */
     @Routed(value = "/s3/:1", priority = 99)
     public void bucket(WebContext ctx, String bucketName) {
@@ -446,6 +447,8 @@ public class S3Controller implements Controller {
         for (Map.Entry<Object, Object> entry : object.getProperties()) {
             response.addHeader(entry.getKey().toString(), entry.getValue().toString());
         }
+        HashCode hash = Files.hash(object.getFile(), Hashing.md5());
+        response.addHeader("ETag", new String(Hex.encode(hash.asBytes())));
         if (sendFile) {
             response.file(object.getFile());
         } else {

--- a/src/main/java/ninja/S3Controller.java
+++ b/src/main/java/ninja/S3Controller.java
@@ -17,7 +17,6 @@ import com.google.common.io.Files;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.bouncycastle.util.encoders.Hex;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -448,7 +447,7 @@ public class S3Controller implements Controller {
             response.addHeader(entry.getKey().toString(), entry.getValue().toString());
         }
         HashCode hash = Files.hash(object.getFile(), Hashing.md5());
-        response.addHeader("ETag", new String(Hex.encode(hash.asBytes())));
+        response.addHeader(HttpHeaders.Names.ETAG, BaseEncoding.base16().encode(hash.asBytes()));
         if (sendFile) {
             response.file(object.getFile());
         } else {


### PR DESCRIPTION
New version of AWS SDK needs ETag header with hex encoded MD5