### PR TITLE
Properly allow the x-amz-date header to override Date

### DIFF
--- a/src/main/java/ninja/AwsLegacyHashCalculator.java
+++ b/src/main/java/ninja/AwsLegacyHashCalculator.java
@@ -68,9 +68,12 @@ public class AwsLegacyHashCalculator {
         stringToSign.append("\n");
         stringToSign.append(ctx.getHeaderValue("Content-Type").asString(""));
         stringToSign.append("\n");
-        stringToSign.append(ctx.get("Expires")
-                               .asString(ctx.getHeaderValue("x-amz-date")
-                                            .asString(ctx.getHeaderValue("Date").asString(""))));
+
+        String date = ctx.get("Expires").asString(
+            ctx.getHeaderValue("Date").asString(""));
+        if (ctx.getHeaderValue("x-amz-date").isNull()) {
+            stringToSign.append(date);
+        }
         stringToSign.append("\n");
 
         HttpHeaders requestHeaders = ctx.getRequest().headers();
@@ -109,7 +112,7 @@ public class AwsLegacyHashCalculator {
     }
 
     private boolean relevantAmazonHeader(final String name) {
-        return name.toLowerCase().startsWith("x-amz-") && !"x-amz-date".equals(name.toLowerCase());
+        return name.toLowerCase().startsWith("x-amz-");
     }
 
     private String toHeaderStringRepresentation(final String headerName, final HttpHeaders requestHeaders) {


### PR DESCRIPTION
The S3 developer guide shows that the Date header should be omitted when the x-amz-date header is provided:

https://s3.amazonaws.com/doc/s3-developer-guide/RESTAuthentication.html

(see Example 2)

This patchset removes x-amz-date from the list of date-like things (e.g. Expires param, Date header) to use in the DATE line (5th line of a canonical string to be signed) and overrides these when present. The result for us is that we can test multipart signed documents with EvaporateJS and s3ninja.