### PR TITLE
Fixes a bug in multipart uploads which truncated latter parts of large files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <version>3.11.2</version>
     </parent>
     <artifactId>s3ninja</artifactId>
-    <version>2.9.1</version>
+    <version>2.9.2</version>
     <packaging>jar</packaging>
     <name>s3-ninja</name>
     <description>S3 ninja emulates the S3 API for development and testing purposes.</description>


### PR DESCRIPTION
This was because `FileChannel.write(ByteBuffer[])` called `sun.nio.ch.IOUtil.write(FileDescriptor, ByteBuffer[])` internally, which (for some unknown reason) iterates only over the first 1024 (JVM-specific cause native constant) elements of the ByteBuffer array.
Therefore large files weren't stored completely on the server side but cut in the middle. 💩  💩 💩 