### PR TITLE
fix docker command

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -59,7 +59,7 @@
             <div class="well">
                 <ol>
                     <li>A readily packaged docker image is available at <a href="https://hub.docker.com/r/scireum/s3-ninja/">scireum/s3-ninja</a></li>
-                    <li>Run like <b>docker run scireum/s3-ninja -p 9444:9000</b></li>
+                    <li>Run like <b>docker run -p 9444:9000 scireum/s3-ninja:6</b></li>
                     <li>Navigate to <a href="http://localhost:9444/ui" target="_blank">http://localhost:9444/ui</a></li>
                     <li>Run S3 API-Calls against <b>http://localhost:9444/</b> (e.g. http://localhost:9444/test-bucket/test-object)</li>
                     <li>Provide an volume for <b>/home/sirius/data</b> to persist data accross restarts.</li>


### PR DESCRIPTION
Move -p to before the container for new newest version of docker.
the original commands fails with:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"-p\": executable file not found in $PATH": unknown.
```
Give container specific tag since latest does not exists in Docker hub any more