### PR TITLE
Allow plain PUT requests to presigned URLs (no signed chunks)

### DIFF
--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -142,7 +142,7 @@ public class S3Dispatcher implements WebDispatcher {
     }
 
     private InputStreamHandler createInputStreamHandler(WebContext ctx) {
-        if (aws4HashCalculator.supports(ctx) && ctx.getRequest().method() == PUT) {
+        if (aws4HashCalculator.supports(ctx) && ctx.getRequest().method() == PUT && ctx.getHeader("x-amz-decoded-content-length") != null) {
             return new SignedChunkHandler();
         } else {
             return new InputStreamHandler();


### PR DESCRIPTION
Before this commit, it was not possible to PUT to a presigned URL unless the request body contained signed chunks. S3 does not require that uploads to presigned URLs are aws-chunked, because it's common to give out an S3 URL when the client is not expected to use an AWS SDK to
upload content.

As per https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html requests that use aws-chunked encoding "must include the `x-amz-decoded-content-length` header" and so we now check for this header. If it is not present, we assume the response body is not aws-chunked.

Closes #114