### PR TITLE
Fix Hash Computation

### DIFF
--- a/src/main/java/ninja/Aws4HashCalculator.java
+++ b/src/main/java/ninja/Aws4HashCalculator.java
@@ -118,7 +118,7 @@ public class Aws4HashCalculator {
     private StringBuilder buildCanonicalRequest(final WebContext ctx, final String signedHeaders) {
         StringBuilder canonicalRequest = new StringBuilder(ctx.getRequest().method().name());
         canonicalRequest.append("\n");
-        canonicalRequest.append(ctx.getRequestedURI());
+        canonicalRequest.append(ctx.getRawRequestedURI());
         canonicalRequest.append("\n");
 
         appendCanonicalQueryString(ctx, canonicalRequest);


### PR DESCRIPTION
- Fixes hash computation to use encoded URL
- This should (at least) fix the hash mismatch when using non-standard characters in file names

Affects #103.