### PR TITLE
Sirius Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <url>http://s3ninja.net</url>
 
     <properties>
-        <sirius.kernel>13.20</sirius.kernel>
-        <sirius.web>24.7</sirius.web>
+        <sirius.kernel>14.0</sirius.kernel>
+        <sirius.web>25.0</sirius.web>
     </properties>
 
     <repositories>


### PR DESCRIPTION
- Upgrades `sirius-web` to [25.0](https://github.com/scireum/sirius-web/releases/tag/25.0)
- Upgrades `sirius-kernel` to [14.0](https://github.com/scireum/sirius-kernel/releases/tag/14.0)
- Code changes do not seem to be necessary.

Closes #133.