### PR TITLE
Corrected the order of command line parameters in the run example

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -59,7 +59,7 @@
             <div class="well">
                 <ol>
                     <li>A readily packaged docker image is available at <a href="https://hub.docker.com/r/scireum/s3-ninja/">scireum/s3-ninja</a></li>
-                    <li>Run like <b>docker run scireum/s3-ninja -p 9444:9000</b></li>
+                    <li>Run like <b>docker run -p 9444:9000 scireum/s3-ninja</b></li>
                     <li>Navigate to <a href="http://localhost:9444/ui" target="_blank">http://localhost:9444/ui</a></li>
                     <li>Run S3 API-Calls against <b>http://localhost:9444/</b> (e.g. http://localhost:9444/test-bucket/test-object)</li>
                     <li>Provide an volume for <b>/home/sirius/data</b> to persist data accross restarts.</li>


### PR DESCRIPTION
Corrected the order of command line parameters in the run example.  The current release of Docker expects that command line parameters meant for the Docker engine occur before the container name.  Only command line parameters meant for the container itself should be specified after the container name.