### PR TITLE
Sirius Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <url>http://s3ninja.net</url>
 
     <properties>
-        <sirius.kernel>14.0</sirius.kernel>
-        <sirius.web>25.0</sirius.web>
+        <sirius.kernel>dev-19.9</sirius.kernel>
+        <sirius.web>dev-29.14</sirius.web>
     </properties>
 
     <repositories>

--- a/src/main/java/ninja/APILog.java
+++ b/src/main/java/ninja/APILog.java
@@ -35,11 +35,11 @@ public class APILog {
      * Represents a log entry.
      */
     public static class Entry {
-        private String tod = NLS.toUserString(LocalDateTime.now());
-        private String function;
-        private String description;
-        private String result;
-        private String duration;
+        private final String tod = NLS.toUserString(LocalDateTime.now());
+        private final String function;
+        private final String description;
+        private final String result;
+        private final String duration;
 
         /**
          * Creates a new log entry.

--- a/src/main/java/ninja/Aws4HashCalculator.java
+++ b/src/main/java/ninja/Aws4HashCalculator.java
@@ -8,7 +8,6 @@
 
 package ninja;
 
-import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import io.netty.handler.codec.http.QueryStringDecoder;
@@ -21,6 +20,7 @@ import sirius.web.http.WebContext;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
@@ -85,7 +85,7 @@ public class Aws4HashCalculator {
         // an extra parameter is given...
         String signedHeaders = matcher.groupCount() == 7 ? matcher.group(6) : ctx.get("X-Amz-SignedHeaders").asString();
 
-        byte[] dateKey = hmacSHA256(("AWS4" + storage.getAwsSecretKey()).getBytes(Charsets.UTF_8), date);
+        byte[] dateKey = hmacSHA256(("AWS4" + storage.getAwsSecretKey()).getBytes(StandardCharsets.UTF_8), date);
         byte[] dateRegionKey = hmacSHA256(dateKey, region);
         byte[] dateRegionServiceKey = hmacSHA256(dateRegionKey, service);
         byte[] signingKey = hmacSHA256(dateRegionServiceKey, serviceType);
@@ -138,7 +138,7 @@ public class Aws4HashCalculator {
     }
 
     private void appendCanonicalQueryString(WebContext ctx, StringBuilder canonicalRequest) {
-        QueryStringDecoder qsd = new QueryStringDecoder(ctx.getRequest().uri(), Charsets.UTF_8);
+        QueryStringDecoder qsd = new QueryStringDecoder(ctx.getRequest().uri(), StandardCharsets.UTF_8);
 
         List<Tuple<String, List<String>>> queryString = Tuple.fromMap(qsd.parameters());
         queryString.sort(Comparator.comparing(Tuple::getFirst));
@@ -172,13 +172,13 @@ public class Aws4HashCalculator {
     }
 
     private String hashedCanonicalRequest(final StringBuilder canonicalRequest) {
-        return Hashing.sha256().hashString(canonicalRequest, Charsets.UTF_8).toString();
+        return Hashing.sha256().hashString(canonicalRequest, StandardCharsets.UTF_8).toString();
     }
 
     private byte[] hmacSHA256(byte[] key, String value) throws NoSuchAlgorithmException, InvalidKeyException {
         SecretKeySpec keySpec = new SecretKeySpec(key, "HmacSHA256");
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(keySpec);
-        return mac.doFinal(value.getBytes(Charsets.UTF_8));
+        return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/ninja/AwsLegacyHashCalculator.java
+++ b/src/main/java/ninja/AwsLegacyHashCalculator.java
@@ -8,7 +8,6 @@
 
 package ninja;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
 import io.netty.handler.codec.http.HttpHeaders;
 import sirius.kernel.commons.Strings;
@@ -18,6 +17,7 @@ import sirius.web.http.WebContext;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -113,7 +113,7 @@ public class AwsLegacyHashCalculator {
         SecretKeySpec keySpec = new SecretKeySpec(storage.getAwsSecretKey().getBytes(), "HmacSHA1");
         Mac mac = Mac.getInstance("HmacSHA1");
         mac.init(keySpec);
-        byte[] result = mac.doFinal(stringToSign.toString().getBytes(Charsets.UTF_8.name()));
+        byte[] result = mac.doFinal(stringToSign.toString().getBytes(StandardCharsets.UTF_8.name()));
         return BaseEncoding.base64().encode(result);
     }
 

--- a/src/main/java/ninja/AwsLegacyHashCalculator.java
+++ b/src/main/java/ninja/AwsLegacyHashCalculator.java
@@ -95,7 +95,7 @@ public class AwsLegacyHashCalculator {
             stringToSign.append("\n");
         }
 
-        stringToSign.append(pathPrefix + "/" + S3Dispatcher.getEffectiveURI(ctx));
+        stringToSign.append(pathPrefix).append('/').append(S3Dispatcher.getEffectiveURI(ctx));
 
         char separator = '?';
         for (String parameterName : ctx.getParameterNames().stream().sorted().collect(Collectors.toList())) {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -38,8 +38,8 @@ import java.util.stream.Stream;
  */
 public class Bucket {
 
-    private File file;
-    private static Cache<String, Boolean> publicAccessCache = CacheManager.createLocalCache("public-bucket-access");
+    private final File file;
+    private static final Cache<String, Boolean> publicAccessCache = CacheManager.createLocalCache("public-bucket-access");
 
     /**
      * Creates a new bucket based on the given directory.

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -9,6 +9,7 @@
 package ninja;
 
 import com.google.common.hash.Hashing;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Counter;
 import sirius.kernel.health.Exceptions;
@@ -89,6 +90,8 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
         return FileVisitResult.CONTINUE;
     }
 
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private String getETag(File file) {
         try {
             return com.google.common.io.Files.asByteSource(file).hash(Hashing.md5()).toString();

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -91,7 +91,7 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
 
     private String getETag(File file) {
         try {
-            return com.google.common.io.Files.hash(file, Hashing.md5()).toString();
+            return com.google.common.io.Files.asByteSource(file).hash(Hashing.md5()).toString();
         } catch (IOException e) {
             Exceptions.ignore(e);
         }

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -26,13 +26,13 @@ import java.nio.file.attribute.BasicFileAttributes;
  */
 class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
 
-    private Counter objectCount;
-    private XMLStructuredOutput output;
-    private int limit;
-    private String marker;
+    private final Counter objectCount;
+    private final XMLStructuredOutput output;
+    private final int limit;
+    private final String marker;
     private String prefix;
-    private boolean useLimit;
-    private boolean usePrefix;
+    private final boolean useLimit;
+    private final boolean usePrefix;
     private boolean markerReached;
 
     // Supressed warning "Null pointers should not be dereferenced"

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -8,11 +8,9 @@
 
 package ninja;
 
-import com.google.common.hash.Hashing;
-import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Counter;
-import sirius.kernel.health.Exceptions;
 import sirius.kernel.xml.XMLStructuredOutput;
 
 import javax.annotation.Nullable;
@@ -90,15 +88,8 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
         return FileVisitResult.CONTINUE;
     }
 
-    @SuppressWarnings({"deprecation", "java:S1874"})
-    @Explain("MD5 is required by Amazon")
     private String getETag(File file) {
-        try {
-            return com.google.common.io.Files.asByteSource(file).hash(Hashing.md5()).toString();
-        } catch (IOException e) {
-            Exceptions.ignore(e);
-        }
-        return null;
+        return Hasher.md5().hashFile(file).toHexString();
     }
 
     public long getCount() {

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -207,7 +207,7 @@ public class NinjaController implements Controller {
             Map<String, String> properties = Maps.newTreeMap();
             properties.put(HttpHeaderNames.CONTENT_TYPE.toString(),
                     ctx.getHeaderValue(HttpHeaderNames.CONTENT_TYPE).asString(MimeHelper.guessMimeType(name)));
-            HashCode hash = Files.hash(object.getFile(), Hashing.md5());
+            HashCode hash = Files.asByteSource(object.getFile()).hash(Hashing.md5());
             String md5 = BaseEncoding.base64().encode(hash.asBytes());
             properties.put("Content-MD5", md5);
             object.storeProperties(properties);

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -16,6 +16,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.PriorityCollector;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -194,6 +195,8 @@ public class NinjaController implements Controller {
      * @param bucket the name of the target bucket
      * @param input  the data stream to read from
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     @Routed(priority = PriorityCollector.DEFAULT_PRIORITY - 1, value = "/ui/:1/upload", jsonCall = true, preDispatchable = true)
     public void uploadFile(WebContext ctx, JSONStructuredOutput out, String bucket, InputStreamHandler input) {
         try {

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -9,14 +9,10 @@
 package ninja;
 
 import com.google.common.collect.Maps;
-import com.google.common.hash.HashCode;
-import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Files;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.PriorityCollector;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -195,8 +191,6 @@ public class NinjaController implements Controller {
      * @param bucket the name of the target bucket
      * @param input  the data stream to read from
      */
-    @SuppressWarnings({"deprecation", "java:S1874"})
-    @Explain("MD5 is required by Amazon")
     @Routed(priority = PriorityCollector.DEFAULT_PRIORITY - 1, value = "/ui/:1/upload", jsonCall = true, preDispatchable = true)
     public void uploadFile(WebContext ctx, JSONStructuredOutput out, String bucket, InputStreamHandler input) {
         try {
@@ -210,8 +204,7 @@ public class NinjaController implements Controller {
             Map<String, String> properties = Maps.newTreeMap();
             properties.put(HttpHeaderNames.CONTENT_TYPE.toString(),
                     ctx.getHeaderValue(HttpHeaderNames.CONTENT_TYPE).asString(MimeHelper.guessMimeType(name)));
-            HashCode hash = Files.asByteSource(object.getFile()).hash(Hashing.md5());
-            String md5 = BaseEncoding.base64().encode(hash.asBytes());
+            String md5 = Hasher.md5().hashFile(object.getFile()).toHexString();
             properties.put("Content-MD5", md5);
             object.storeProperties(properties);
 

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -204,7 +204,7 @@ public class NinjaController implements Controller {
             Map<String, String> properties = Maps.newTreeMap();
             properties.put(HttpHeaderNames.CONTENT_TYPE.toString(),
                     ctx.getHeaderValue(HttpHeaderNames.CONTENT_TYPE).asString(MimeHelper.guessMimeType(name)));
-            String md5 = Hasher.md5().hashFile(object.getFile()).toHexString();
+            String md5 = Hasher.md5().hashFile(object.getFile()).toBase64String();
             properties.put("Content-MD5", md5);
             object.storeProperties(properties);
 

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -1056,7 +1056,7 @@ public class S3Dispatcher implements WebDispatcher {
             out.beginObject("Part");
             out.property("PartNumber", part.getName());
             out.property("LastModified", ISO8601_INSTANT.format(Instant.ofEpochMilli(part.lastModified())));
-            out.property(HTTP_HEADER_NAME_ETAG, Hasher.md5().hashFile(part).toBase64String());
+            out.property(HTTP_HEADER_NAME_ETAG, Hasher.md5().hashFile(part).toHexString());
             out.property("Size", part.length());
             out.endObject();
         }

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -103,9 +103,9 @@ public class S3Dispatcher implements WebDispatcher {
     @ConfigValue("storage.multipartDir")
     private String multipartDir;
 
-    private Set<String> multipartUploads = Collections.synchronizedSet(new TreeSet<>());
+    private final Set<String> multipartUploads = Collections.synchronizedSet(new TreeSet<>());
 
-    private Counter uploadIdCounter = new Counter();
+    private final Counter uploadIdCounter = new Counter();
 
     /**
      * ISO 8601 date/time formatter.

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -23,6 +23,7 @@ import ninja.errors.S3ErrorSynthesizer;
 import ninja.queries.S3QuerySynthesizer;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Callback;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -622,6 +623,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param bucket the bucket containing the object to upload
      * @param id     name of the object to upload
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void putObject(WebContext ctx, Bucket bucket, String id, InputStreamHandler inputStream)
             throws IOException {
         StoredObject object = bucket.getObject(id);
@@ -679,6 +682,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param bucket the bucket containing the object to use as destination
      * @param id     name of the object to use as destination
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void copyObject(WebContext ctx, Bucket bucket, String id, String copy) throws IOException {
         StoredObject object = bucket.getObject(id);
         if (!copy.contains(PATH_DELIMITER)) {
@@ -735,6 +740,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param bucket the bucket containing the object to download
      * @param id     name of the object to use as download
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void getObject(WebContext ctx, Bucket bucket, String id, boolean sendFile) throws IOException {
         StoredObject object = bucket.getObject(id);
         if (!object.exists()) {
@@ -829,6 +836,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param partNumber the number of this part in the complete upload
      * @param part       input stream with the content of this part
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void multiObject(WebContext ctx, String uploadId, String partNumber, InputStreamHandler part) {
         if (!multipartUploads.contains(uploadId)) {
             errorSynthesizer.synthesiseError(ctx,
@@ -872,6 +881,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param uploadId the multipart upload that should be completed
      * @param in       input stream with xml listing uploaded parts
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void completeMultipartUpload(WebContext ctx,
                                          Bucket bucket,
                                          String id,
@@ -1016,6 +1027,8 @@ public class S3Dispatcher implements WebDispatcher {
      * @param bucket the bucket containing the object to download
      * @param id     name of the object to use as download
      */
+    @SuppressWarnings({"deprecation", "java:S1874"})
+    @Explain("MD5 is required by Amazon")
     private void getPartList(WebContext ctx, Bucket bucket, String id, String uploadId) {
         if (!multipartUploads.contains(uploadId)) {
             errorSynthesizer.synthesiseError(ctx,

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -634,7 +634,7 @@ public class S3Dispatcher implements WebDispatcher {
         }
 
         Map<String, String> properties = parseUploadProperties(ctx);
-        HashCode hash = Files.hash(object.getFile(), Hashing.md5());
+        HashCode hash = Files.asByteSource(object.getFile()).hash(Hashing.md5());
         String md5 = BaseEncoding.base64().encode(hash.asBytes());
         String contentMd5 = properties.get("Content-MD5");
         if (properties.containsKey("Content-MD5") && !md5.equals(contentMd5)) {
@@ -713,7 +713,7 @@ public class S3Dispatcher implements WebDispatcher {
         if (src.getPropertiesFile().exists()) {
             Files.copy(src.getPropertiesFile(), object.getPropertiesFile());
         }
-        HashCode hash = Files.hash(object.getFile(), Hashing.md5());
+        HashCode hash = Files.asByteSource(object.getFile()).hash(Hashing.md5());
         String etag = BaseEncoding.base16().encode(hash.asBytes()).toLowerCase();
 
         XMLStructuredOutput structuredOutput = ctx.respondWith().addHeader(HTTP_HEADER_NAME_ETAG, etag(etag)).xml();
@@ -752,7 +752,7 @@ public class S3Dispatcher implements WebDispatcher {
 
         String etag = properties.getProperty(HTTP_HEADER_NAME_ETAG);
         if (Strings.isEmpty(etag)) {
-            HashCode hash = Files.hash(object.getFile(), Hashing.md5());
+            HashCode hash = Files.asByteSource(object.getFile()).hash(Hashing.md5());
             etag = BaseEncoding.base16().encode(hash.asBytes()).toLowerCase();
             Map<String, String> data = new HashMap<>();
             properties.forEach((key, value) -> data.put(key.toString(), String.valueOf(value)));
@@ -849,7 +849,7 @@ public class S3Dispatcher implements WebDispatcher {
             }
             part.close();
 
-            String etag = BaseEncoding.base16().encode(Files.hash(partFile, Hashing.md5()).asBytes()).toLowerCase();
+            String etag = BaseEncoding.base16().encode(Files.asByteSource(partFile).hash(Hashing.md5()).asBytes()).toLowerCase();
             ctx.respondWith()
                .setHeader(HTTP_HEADER_NAME_ETAG, etag)
                .addHeader(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, HTTP_HEADER_NAME_ETAG)
@@ -924,7 +924,7 @@ public class S3Dispatcher implements WebDispatcher {
 
             delete(getUploadDir(uploadId));
 
-            String etag = Files.hash(object.getFile(), Hashing.md5()).toString();
+            String etag = Files.asByteSource(object.getFile()).hash(Hashing.md5()).toString();
 
             // Update the ETAG of the underlying object...
             Properties properties = object.getProperties();
@@ -1064,7 +1064,7 @@ public class S3Dispatcher implements WebDispatcher {
             out.property("PartNumber", part.getName());
             out.property("LastModified", ISO8601_INSTANT.format(Instant.ofEpochMilli(part.lastModified())));
             try {
-                out.property(HTTP_HEADER_NAME_ETAG, Files.hash(part, Hashing.md5()).toString());
+                out.property(HTTP_HEADER_NAME_ETAG, Files.asByteSource(part).hash(Hashing.md5()).toString());
             } catch (IOException e) {
                 Exceptions.ignore(e);
             }

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -211,35 +211,35 @@ public class S3Dispatcher implements WebDispatcher {
     }
 
     @Override
-    public boolean dispatch(WebContext ctx) throws Exception {
+    public DispatchDecision dispatch(WebContext ctx) throws Exception {
         S3Request request = parseRequest(ctx);
 
         if (request.uri.equals(UI_PATH) || request.uri.startsWith(UI_PATH_PREFIX)) {
-            return false;
+            return DispatchDecision.CONTINUE;
         }
 
         if (Strings.isFilled(request.query)) {
             forwardQueryToSynthesizer(ctx, request);
-            return true;
+            return DispatchDecision.DONE;
         }
 
         if (Strings.isEmpty(request.bucket)) {
             listBuckets(ctx);
-            return true;
+            return DispatchDecision.DONE;
         }
 
         if (Strings.isEmpty(request.key)) {
             bucket(ctx, request.bucket);
-            return true;
+            return DispatchDecision.DONE;
         }
 
         Bucket bucket = storage.getBucket(request.bucket);
         if (!bucket.exists() && !storage.isAutocreateBuckets()) {
-            return false;
+            return DispatchDecision.CONTINUE;
         }
 
         readObject(ctx, request.bucket, request.key);
-        return true;
+        return DispatchDecision.DONE;
     }
 
     /**

--- a/src/main/java/ninja/SignedChunkHandler.java
+++ b/src/main/java/ninja/SignedChunkHandler.java
@@ -26,7 +26,7 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
     /**
      * Temporary buffer object used for caching incomplete chunks.
      */
-    private ByteBuf chunkBuffer = Unpooled.buffer();
+    private final ByteBuf chunkBuffer = Unpooled.buffer();
 
     @Override
     public void handle(ByteBuf content, boolean last) throws IOException {

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -23,7 +23,7 @@ import java.util.Properties;
  * Represents a stored object.
  */
 public class StoredObject {
-    private File file;
+    private final File file;
 
     /**
      * Creates a new StoredObject based on a file.


### PR DESCRIPTION
> https://scireum.myjetbrains.com/youtrack/issue/SIRI-257

- Upgrades `sirius-kernel` to `dev-19.9`
- Upgrades `sirius.web` to `dev-29.14`
- Fixes deprecation warnings concerning `Files.hash(..., ...)` with `Files.asByteSource(...).hash(...)`
- Suppresses deprecation warnings concerning `Hashing.md5()`

Possibly affects #147.