### PR TITLE
Support for Arbitrary Object Keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <url>http://s3ninja.net</url>
 
     <properties>
-        <sirius.kernel>dev-20.0</sirius.kernel>
-        <sirius.web>dev-30.0</sirius.web>
+        <sirius.kernel>dev-21.0.1</sirius.kernel>
+        <sirius.web>dev-33.0.1</sirius.web>
     </properties>
 
     <repositories>

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -103,11 +103,7 @@ public class Bucket {
      * @return the encoded name of the bucket
      */
     public String getEncodedName() {
-        try {
-            return URLEncoder.encode(getName(), StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            return getName();
-        }
+        return Strings.urlEncode(getName());
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -225,20 +225,26 @@ public class Bucket {
     }
 
     /**
-     * Returns the child object with the given id.
+     * Returns the object with the given key.
+     * <p>
+     * The method never returns <b>null</b>, but {@link StoredObject#exists()} may return <b>false</b>.
+     * <p>
+     * Make sure that the key passes {@link StoredObject#isValidKey(String)} by meeting the naming restrictions
+     * documented there.
      *
-     * @param id the name of the requested child object. Must not contain .. / or \
-     * @return the object with the given id, might not exist, but is always non null
+     * @param key the key of the requested object
+     * @return the object with the given key
      */
-    public StoredObject getObject(String id) {
-        if (id.contains("..") || id.contains("/") || id.contains("\\")) {
+    @Nonnull
+    public StoredObject getObject(String key) {
+        if (!StoredObject.isValidKey(key)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
-                                    "Invalid object name: %s. A object name must not contain '..' '/' or '\\'",
-                                    id)
+                                    "Invalid object key: %s. The key is empty.",
+                                    key)
                             .handle();
         }
-        return new StoredObject(new File(file, id));
+        return new StoredObject(new File(file, key));
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -283,7 +283,8 @@ public class Bucket {
                                     key)
                             .handle();
         }
-        return new StoredObject(new File(folder, key));
+
+        return new StoredObject(folder, key);
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -426,7 +426,7 @@ public class Bucket {
         File legacyProperties = new File(folder, "__ninja_" + legacyChild.getName() + ".properties");
 
         try {
-            File child = new File(folder, URLEncoder.encode(legacyChild.getName(), StandardCharsets.UTF_8.name()));
+            File child = new File(folder, StoredObject.encodeKey(legacyChild.getName()));
             File properties = new File(folder, "$" + child.getName() + ".properties");
 
             if (!child.exists()) {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -178,7 +178,7 @@ public class Bucket {
         try {
             walkFileTreeOurWay(folder.toPath(), visitor);
         } catch (IOException e) {
-            Exceptions.handle(e);
+            throw Exceptions.handle(e);
         }
         output.property("IsTruncated", limit > 0 && visitor.getCount() > limit);
         output.endOutput();
@@ -204,7 +204,7 @@ public class Bucket {
                     BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
                     visitor.visitFile(p, attrs);
                 } catch (IOException e) {
-                    Exceptions.handle(e);
+                    throw Exceptions.handle(e);
                 }
             });
         }

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -249,7 +249,7 @@ public class Bucket {
      * @param limit the limit to apply
      * @return all files containing the query, restricted by the limit
      */
-    public List<StoredObject> getObjects(@Nonnull String query, Limit limit) {
+    public List<StoredObject> getObjects(@Nullable String query, Limit limit) {
         try (Stream<Path> stream = Files.list(file.toPath())) {
             return stream.sorted(Bucket::compareUtf8Binary)
                          .map(Path::toFile)
@@ -262,7 +262,7 @@ public class Bucket {
         }
     }
 
-    private boolean isMatchingObject(@Nonnull String query, File currentFile) {
+    private boolean isMatchingObject(@Nullable String query, File currentFile) {
         return (Strings.isEmpty(query) || currentFile.getName().contains(query)) && currentFile.isFile() && !currentFile
                 .getName()
                 .startsWith("__");
@@ -274,7 +274,7 @@ public class Bucket {
      * @param query the query to filter for
      * @return the number of files in the bucket matching the query
      */
-    public int countObjects(@Nonnull String query) {
+    public int countObjects(@Nullable String query) {
         try (Stream<Path> stream = Files.list(file.toPath())) {
             return Math.toIntExact(stream.map(Path::toFile)
                                          .filter(currentFile -> isMatchingObject(query, currentFile))

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -169,7 +169,7 @@ public class Bucket {
     /**
      * Determines if the bucket is only privately accessible, i.e. non-public.
      *
-     * @return <b>true</b> if the bucket is privately accessible, <b>false</b> else
+     * @return <b>true</b> if the bucket is only privately accessible, <b>false</b> else
      */
     public boolean isPrivate() {
         return !Boolean.TRUE.equals(publicAccessCache.get(getName(), key -> getPublicMarkerFile().exists()));
@@ -248,12 +248,12 @@ public class Bucket {
     }
 
     /**
-     * Returns a number of files containing the given query, within the given indexing limits. Leave the query empty to
+     * Returns a number of files meeting the given query, within the given indexing limits. Leave the query empty to
      * get all files.
      *
      * @param query the query to filter for
      * @param limit the limit to apply
-     * @return all files containing the query, restricted by the limit
+     * @return all files meeting the query, restricted by the limit
      */
     public List<StoredObject> getObjects(@Nullable String query, Limit limit) {
         try (Stream<Path> stream = Files.list(file.toPath())) {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -98,8 +99,12 @@ public class Bucket {
      * @return true if all files of the bucket and the bucket itself was deleted successfully, false otherwise.
      */
     public boolean delete() {
+        if (!file.exists()) {
+            return true;
+        }
+
         boolean deleted = false;
-        for (File child : file.listFiles()) {
+        for (File child : Objects.requireNonNull(file.listFiles())) {
             deleted = child.delete() || deleted;
         }
         deleted = file.delete() || deleted;

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -211,8 +211,8 @@ public class Bucket {
     }
 
     private static int compareUtf8Binary(Path p1, Path p2) {
-        String s1 = p1.getFileName().toString();
-        String s2 = p2.getFileName().toString();
+        String s1 = StoredObject.decodeKey(p1.getFileName().toString());
+        String s2 = StoredObject.decodeKey(p2.getFileName().toString());
 
         byte[] b1 = s1.getBytes(StandardCharsets.UTF_8);
         byte[] b2 = s2.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -167,9 +167,9 @@ public class Bucket {
     }
 
     /**
-     * Determines if the bucket is private or public accessible
+     * Determines if the bucket is only privately accessible, i.e. non-public.
      *
-     * @return <tt>true</tt> if the bucket is public accessible, <tt>false</tt> otherwise
+     * @return <b>true</b> if the bucket is privately accessible, <b>false</b> else
      */
     public boolean isPrivate() {
         return !Boolean.TRUE.equals(publicAccessCache.get(getName(), key -> getPublicMarkerFile().exists()));
@@ -180,7 +180,7 @@ public class Bucket {
     }
 
     /**
-     * Marks the bucket as private accessible.
+     * Marks the bucket as only privately accessible, i.e. non-public.
      */
     public void makePrivate() {
         if (getPublicMarkerFile().exists()) {
@@ -193,7 +193,7 @@ public class Bucket {
     }
 
     /**
-     * Marks the bucket as public accessible.
+     * Marks the bucket as publicly accessible.
      */
     public void makePublic() {
         if (!getPublicMarkerFile().exists()) {
@@ -207,9 +207,9 @@ public class Bucket {
     }
 
     /**
-     * Returns the underlying directory as File.
+     * Returns the underlying directory as {@link File}.
      *
-     * @return a <tt>File</tt> representing the underlying directory
+     * @return a {@link File} representing the underlying directory
      */
     public File getFile() {
         return file;
@@ -218,7 +218,7 @@ public class Bucket {
     /**
      * Determines if the bucket exists.
      *
-     * @return <tt>true</tt> if the bucket exists, <tt>false</tt> otherwise
+     * @return <b>true</b> if the bucket exists, <b>false</b> else
      */
     public boolean exists() {
         return file.exists();
@@ -242,12 +242,12 @@ public class Bucket {
     }
 
     /**
-     * Get <tt>size</tt> number of files, starting at <tt>start</tt>. Only get files containing the query. Leave the
-     * query empty to get all files.
+     * Returns a number of files containing the given query, within the given indexing limits. Leave the query empty to
+     * get all files.
      *
      * @param query the query to filter for
      * @param limit the limit to apply
-     * @return all files which contain the query
+     * @return all files containing the query, restricted by the limit
      */
     public List<StoredObject> getObjects(@Nonnull String query, Limit limit) {
         try (Stream<Path> stream = Files.list(file.toPath())) {
@@ -297,7 +297,7 @@ public class Bucket {
      * rules</a> are much more strict.
      *
      * @param name the name to check
-     * @return <b>true</b> if the name is valid as bucket name
+     * @return <b>true</b> if the name is valid as bucket name, <b>false</b> else
      */
     public static boolean isValidName(@Nullable String name) {
         if (name == null || Strings.isEmpty(name.trim())) {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -373,17 +373,7 @@ public class Bucket {
      */
     private void migrateBucket(int fromVersion) {
         if (fromVersion <= 1) {
-            try {
-                // migrate public marker
-                File legacyPublicMarker = new File(folder, "__ninja_public");
-                if (legacyPublicMarker.exists() && !publicMarker.exists()) {
-                    Files.move(legacyPublicMarker.toPath(), publicMarker.toPath());
-                } else if (legacyPublicMarker.exists()) {
-                    Files.delete(legacyPublicMarker.toPath());
-                }
-            } catch (IOException e) {
-                throw Exceptions.handle(Storage.LOG, e);
-            }
+            migratePublicMarkerVersion1To2();
 
             // todo: migrate files and properties
         }
@@ -392,6 +382,22 @@ public class Bucket {
 
         // write the most recent version marker
         setVersion(MOST_RECENT_VERSION);
+    }
+
+    /**
+     * Migrates a version 1 public marker file to version 2.
+     */
+    private void migratePublicMarkerVersion1To2() {
+        try {
+            File legacyPublicMarker = new File(folder, "__ninja_public");
+            if (legacyPublicMarker.exists() && !publicMarker.exists()) {
+                Files.move(legacyPublicMarker.toPath(), publicMarker.toPath());
+            } else if (legacyPublicMarker.exists()) {
+                Files.delete(legacyPublicMarker.toPath());
+            }
+        } catch (IOException e) {
+            throw Exceptions.handle(Storage.LOG, e);
+        }
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -172,7 +172,7 @@ public class Bucket {
      * @return <tt>true</tt> if the bucket is public accessible, <tt>false</tt> otherwise
      */
     public boolean isPrivate() {
-        return !publicAccessCache.get(getName(), key -> getPublicMarkerFile().exists());
+        return !Boolean.TRUE.equals(publicAccessCache.get(getName(), key -> getPublicMarkerFile().exists()));
     }
 
     private File getPublicMarkerFile() {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -283,4 +283,28 @@ public class Bucket {
             throw Exceptions.handle(e);
         }
     }
+
+    /**
+     * Checks whether the given string is valid for use as bucket name.
+     * <p>
+     * Currently, the name must not be effectively empty, must not equal the single dot, and it must not contain:
+     * <ul>
+     *     <li><tt>/</tt> (forward slashes)</li>
+     *     <li><tt>\</tt> (backward slashes)</li>
+     *     <li><tt>..</tt> (two consecutive dots)</li>
+     * </ul>
+     * Note that the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html">official naming
+     * rules</a> are much more strict.
+     *
+     * @param name the name to check
+     * @return <b>true</b> if the name is valid as bucket name
+     */
+    public static boolean isValidName(@Nullable String name) {
+        if (name == null || Strings.isEmpty(name.trim())) {
+            return false;
+        }
+
+        // todo: check full official naming rules
+        return !name.equals(".") && !name.contains("..") && !name.contains("/") && !name.contains("\\");
+    }
 }

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -59,13 +59,13 @@ public class Bucket {
 
     private static final int MOST_RECENT_VERSION = BucketMigrator.MOST_RECENT_VERSION;
 
-    protected int version;
+    private int version;
 
-    protected final File folder;
+    private final File folder;
 
-    protected final File versionMarker;
+    private final File versionMarker;
 
-    protected final File publicMarker;
+    private final File publicMarker;
 
     private static final Cache<String, Boolean> publicAccessCache = CacheManager.createLocalCache("public-bucket-access");
 
@@ -113,6 +113,14 @@ public class Bucket {
      */
     public File getFolder() {
         return folder;
+    }
+
+    protected File getVersionMarker() {
+        return versionMarker;
+    }
+
+    protected File getPublicMarker() {
+        return publicMarker;
     }
 
     /**
@@ -329,6 +337,14 @@ public class Bucket {
         return (Strings.isEmpty(query) || currentFile.getName().contains(query)) && currentFile.isFile() && !currentFile
                 .getName()
                 .startsWith("$");
+    }
+
+    protected int getVersion() {
+        return version;
+    }
+
+    protected void setVersion(int version) {
+        this.version = version;
     }
 
     private int parseVersion() {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -404,7 +404,7 @@ public class Bucket {
     }
 
     /**
-     * Migrates a version 1 public marker file to version 2.
+     * Migrates the legacy public marker file <tt>__ninja_public</tt> to <tt>$public</tt>.
      */
     private void migratePublicMarkerVersion1To2() {
         try {
@@ -419,17 +419,25 @@ public class Bucket {
         }
     }
 
-    private void migrateObjectVersion1To2(File legacyChild) {
-        File legacyProperties = new File(folder, "__ninja_" + legacyChild.getName() + ".properties");
+    /**
+     * Migrates a legacy object along with its properties.
+     * <p>
+     * The legacy file name is considered as-is and URL-encoded for general UTF-8 support. The properties file is
+     * prefixed with <tt>$</tt>, avoiding name clashes with other object files (where <tt>$</tt> would be encoded).
+     *
+     * @param legacyObject the legacy object to migrate
+     */
+    private void migrateObjectVersion1To2(File legacyObject) {
+        File legacyProperties = new File(folder, "__ninja_" + legacyObject.getName() + ".properties");
 
         try {
-            File child = new File(folder, StoredObject.encodeKey(legacyChild.getName()));
-            File properties = new File(folder, "$" + child.getName() + ".properties");
+            File object = new File(folder, StoredObject.encodeKey(legacyObject.getName()));
+            File properties = new File(folder, "$" + object.getName() + ".properties");
 
-            if (!child.exists()) {
-                Files.move(legacyChild.toPath(), child.toPath());
-            } else if (!child.equals(legacyChild)) {
-                Files.delete(legacyChild.toPath());
+            if (!object.exists()) {
+                Files.move(legacyObject.toPath(), object.toPath());
+            } else if (!object.equals(legacyObject)) {
+                Files.delete(legacyObject.toPath());
             }
 
             if (legacyProperties.exists()) {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -94,6 +94,35 @@ public class Bucket {
     }
 
     /**
+     * Returns the underlying directory as {@link File}.
+     *
+     * @return a {@link File} representing the underlying directory
+     */
+    public File getFolder() {
+        return folder;
+    }
+
+    /**
+     * Determines if the bucket exists.
+     *
+     * @return <b>true</b> if the bucket exists, <b>false</b> else
+     */
+    public boolean exists() {
+        return folder.exists();
+    }
+
+    /**
+     * Creates the bucket.
+     * <p>
+     * If the underlying directory already exists, nothing happens.
+     *
+     * @return true if the folder for the bucket was created successfully if it was missing before.
+     */
+    public boolean create() {
+        return !folder.exists() && folder.mkdirs();
+    }
+
+    /**
      * Deletes the bucket and all of its contents.
      *
      * @return true if all files of the bucket and the bucket itself was deleted successfully, false otherwise.
@@ -109,17 +138,6 @@ public class Bucket {
         }
         deleted = folder.delete() || deleted;
         return deleted;
-    }
-
-    /**
-     * Creates the bucket.
-     * <p>
-     * If the underlying directory already exists, nothing happens.
-     *
-     * @return true if the folder for the bucket was created successfully if it was missing before.
-     */
-    public boolean create() {
-        return !folder.exists() && folder.mkdirs();
     }
 
     /**
@@ -228,24 +246,6 @@ public class Bucket {
             }
         }
         publicAccessCache.put(getName(), true);
-    }
-
-    /**
-     * Returns the underlying directory as {@link File}.
-     *
-     * @return a {@link File} representing the underlying directory
-     */
-    public File getFolder() {
-        return folder;
-    }
-
-    /**
-     * Determines if the bucket exists.
-     *
-     * @return <b>true</b> if the bucket exists, <b>false</b> else
-     */
-    public boolean exists() {
-        return folder.exists();
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -330,7 +330,7 @@ public class Bucket {
     private boolean isMatchingObject(@Nullable String query, File currentFile) {
         return (Strings.isEmpty(query) || currentFile.getName().contains(query)) && currentFile.isFile() && !currentFile
                 .getName()
-                .startsWith("__");
+                .startsWith("$");
     }
 
     private int getVersion() {

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -384,8 +384,13 @@ public class Bucket {
     }
 
     private boolean filterObjects(File file) {
-        // ignore directories
-        if (file.isDirectory()) {
+        // ignore directories and other strange stuff
+        if (!file.isFile()) {
+            return false;
+        }
+
+        // ignore files not residing in our own folder
+        if (!folder.equals(file.getParentFile())) {
             return false;
         }
 

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -287,12 +287,6 @@ public class Bucket {
         }
     }
 
-    private boolean isMatchingObject(@Nullable String query, File currentFile) {
-        return (Strings.isEmpty(query) || currentFile.getName().contains(query)) && currentFile.isFile() && !currentFile
-                .getName()
-                .startsWith("__");
-    }
-
     /**
      * Count the files containing the query. Leave the query empty to count all files.
      *
@@ -307,6 +301,12 @@ public class Bucket {
         } catch (IOException e) {
             throw Exceptions.handle(e);
         }
+    }
+
+    private boolean isMatchingObject(@Nullable String query, File currentFile) {
+        return (Strings.isEmpty(query) || currentFile.getName().contains(query)) && currentFile.isFile() && !currentFile
+                .getName()
+                .startsWith("__");
     }
 
     /**

--- a/src/main/java/ninja/Bucket.java
+++ b/src/main/java/ninja/Bucket.java
@@ -259,7 +259,7 @@ public class Bucket {
         if (!StoredObject.isValidKey(key)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
-                                    "Invalid object key: %s. The key is empty.",
+                                    "Object key \"%s\" does not adhere to the rules. [https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html]",
                                     key)
                             .handle();
         }

--- a/src/main/java/ninja/BucketMigrator.java
+++ b/src/main/java/ninja/BucketMigrator.java
@@ -31,14 +31,14 @@ public class BucketMigrator {
      * @param bucket the bucket to migrate
      */
     protected static void migrateBucket(Bucket bucket) {
-        if (bucket.version <= 1) {
+        if (bucket.getVersion() <= 1) {
             migrateBucketVersion1To2(bucket);
         }
 
         // further incremental updates go here one day
 
         // write the most recent version marker
-        bucket.version = MOST_RECENT_VERSION;
+        bucket.setVersion(MOST_RECENT_VERSION);
         bucket.writeVersion();
     }
 
@@ -50,7 +50,7 @@ public class BucketMigrator {
     private static void migrateBucketVersion1To2(Bucket bucket) {
         migratePublicMarkerVersion1To2(bucket);
 
-        for (File object : Objects.requireNonNull(bucket.folder.listFiles(bucket::filterObjects))) {
+        for (File object : Objects.requireNonNull(bucket.getFolder().listFiles(bucket::filterObjects))) {
             migrateObjectVersion1To2(bucket, object);
         }
     }
@@ -62,9 +62,9 @@ public class BucketMigrator {
      */
     private static void migratePublicMarkerVersion1To2(Bucket bucket) {
         try {
-            File legacyPublicMarker = new File(bucket.folder, "__ninja_public");
-            if (legacyPublicMarker.exists() && !bucket.publicMarker.exists()) {
-                Files.move(legacyPublicMarker.toPath(), bucket.publicMarker.toPath());
+            File legacyPublicMarker = new File(bucket.getFolder(), "__ninja_public");
+            if (legacyPublicMarker.exists() && !bucket.getPublicMarker().exists()) {
+                Files.move(legacyPublicMarker.toPath(), bucket.getPublicMarker().toPath());
             } else if (legacyPublicMarker.exists()) {
                 Files.delete(legacyPublicMarker.toPath());
             }
@@ -83,11 +83,11 @@ public class BucketMigrator {
      * @param legacyObject the legacy object to migrate
      */
     private static void migrateObjectVersion1To2(Bucket bucket, File legacyObject) {
-        File legacyProperties = new File(bucket.folder, "__ninja_" + legacyObject.getName() + ".properties");
+        File legacyProperties = new File(bucket.getFolder(), "__ninja_" + legacyObject.getName() + ".properties");
 
         try {
-            File object = new File(bucket.folder, StoredObject.encodeKey(legacyObject.getName()));
-            File properties = new File(bucket.folder, "$" + object.getName() + ".properties");
+            File object = new File(bucket.getFolder(), StoredObject.encodeKey(legacyObject.getName()));
+            File properties = new File(bucket.getFolder(), "$" + object.getName() + ".properties");
 
             if (!object.exists()) {
                 Files.move(legacyObject.toPath(), object.toPath());

--- a/src/main/java/ninja/BucketMigrator.java
+++ b/src/main/java/ninja/BucketMigrator.java
@@ -1,0 +1,109 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package ninja;
+
+import sirius.kernel.health.Exceptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+
+/**
+ * Provides static helpers for migrating bucket data.
+ */
+public class BucketMigrator {
+
+    protected static final int MOST_RECENT_VERSION = 2;
+
+    private BucketMigrator() {
+    }
+
+    /**
+     * Migrates a bucket folder to the most recent version.
+     *
+     * @param bucket the bucket to migrate
+     */
+    protected static void migrateBucket(Bucket bucket) {
+        if (bucket.version <= 1) {
+            migrateBucketVersion1To2(bucket);
+        }
+
+        // further incremental updates go here one day
+
+        // write the most recent version marker
+        bucket.version = MOST_RECENT_VERSION;
+        bucket.writeVersion();
+    }
+
+    /**
+     * Migrates a bucket folder from version 1 to 2.
+     *
+     * @param bucket the bucket to migrate
+     */
+    private static void migrateBucketVersion1To2(Bucket bucket) {
+        migratePublicMarkerVersion1To2(bucket);
+
+        for (File object : Objects.requireNonNull(bucket.folder.listFiles(bucket::filterObjects))) {
+            migrateObjectVersion1To2(bucket, object);
+        }
+    }
+
+    /**
+     * Migrates the legacy public marker file <tt>__ninja_public</tt> to <tt>$public</tt>.
+     *
+     * @param bucket the bucket to migrate
+     */
+    private static void migratePublicMarkerVersion1To2(Bucket bucket) {
+        try {
+            File legacyPublicMarker = new File(bucket.folder, "__ninja_public");
+            if (legacyPublicMarker.exists() && !bucket.publicMarker.exists()) {
+                Files.move(legacyPublicMarker.toPath(), bucket.publicMarker.toPath());
+            } else if (legacyPublicMarker.exists()) {
+                Files.delete(legacyPublicMarker.toPath());
+            }
+        } catch (IOException e) {
+            throw Exceptions.handle(Storage.LOG, e);
+        }
+    }
+
+    /**
+     * Migrates a legacy object along with its properties.
+     * <p>
+     * The legacy file name is considered as-is and URL-encoded for general UTF-8 support. The properties file is
+     * prefixed with <tt>$</tt>, avoiding name clashes with other object files (where <tt>$</tt> would be encoded).
+     *
+     * @param bucket the bucket to migrate
+     * @param legacyObject the legacy object to migrate
+     */
+    private static void migrateObjectVersion1To2(Bucket bucket, File legacyObject) {
+        File legacyProperties = new File(bucket.folder, "__ninja_" + legacyObject.getName() + ".properties");
+
+        try {
+            File object = new File(bucket.folder, StoredObject.encodeKey(legacyObject.getName()));
+            File properties = new File(bucket.folder, "$" + object.getName() + ".properties");
+
+            if (!object.exists()) {
+                Files.move(legacyObject.toPath(), object.toPath());
+            } else if (!object.equals(legacyObject)) {
+                Files.delete(legacyObject.toPath());
+            }
+
+            if (legacyProperties.exists()) {
+                if (!properties.exists()) {
+                    Files.move(legacyProperties.toPath(), properties.toPath());
+                } else if (!properties.equals(legacyProperties)) {
+                    Files.delete(legacyProperties.toPath());
+                }
+            }
+        } catch (Exception e) {
+            throw Exceptions.handle(Storage.LOG, e);
+        }
+    }
+}

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -49,9 +49,6 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
         objectCount = new Counter();
         useLimit = limit > 0;
         usePrefix = Strings.isFilled(prefix);
-        if (usePrefix) {
-            this.prefix = prefix.replace('/', '_');
-        }
         markerReached = Strings.isEmpty(marker);
     }
 

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -70,10 +70,10 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
                 long numObjects = objectCount.inc();
                 if (numObjects <= limit) {
                     output.beginObject("Contents");
-                    output.property("Key", file.getName());
+                    output.property("Key", object.getKey());
                     output.property("LastModified",
                                     S3Dispatcher.ISO8601_INSTANT.format(object.getLastModifiedInstant()));
-                    output.property("Size", file.length());
+                    output.property("Size", object.getSizeBytes());
                     output.property("StorageClass", "STANDARD");
                     output.property("ETag", getETag(file));
                     output.endObject();

--- a/src/main/java/ninja/ListFileTreeVisitor.java
+++ b/src/main/java/ninja/ListFileTreeVisitor.java
@@ -60,7 +60,7 @@ class ListFileTreeVisitor extends SimpleFileVisitor<Path> {
         File file = path.toFile();
         String name = file.getName();
 
-        if (!file.isFile() || name.startsWith("__")) {
+        if (!file.isFile() || name.startsWith("$")) {
             return FileVisitResult.CONTINUE;
         }
         if (!markerReached) {

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -224,9 +224,8 @@ public class NinjaController extends BasicController {
             properties.put(HttpHeaderNames.CONTENT_TYPE.toString(),
                            webContext.getHeaderValue(HttpHeaderNames.CONTENT_TYPE)
                                      .asString(MimeHelper.guessMimeType(name)));
-            String md5 = Hasher.md5().hashFile(object.getFile()).toBase64String();
-            properties.put("Content-MD5", md5);
-            object.storeProperties(properties);
+            properties.put("Content-MD5", Hasher.md5().hashFile(object.getFile()).toBase64String());
+            object.setProperties(properties);
 
             webContext.respondWith()
                       .json()
@@ -298,8 +297,8 @@ public class NinjaController extends BasicController {
         }
 
         Response response = webContext.respondWith();
-        for (Map.Entry<Object, Object> entry : object.getProperties().entrySet()) {
-            response.addHeader(entry.getKey().toString(), entry.getValue().toString());
+        for (Map.Entry<String, String> entry : object.getProperties().entrySet()) {
+            response.addHeader(entry.getKey(), entry.getValue());
         }
         response.file(object.getFile());
     }

--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -273,38 +273,34 @@ public class NinjaController extends BasicController {
      */
     @Routed(value = "/ui/:1/**", priority = PriorityCollector.DEFAULT_PRIORITY + 1)
     public void object(WebContext webContext, String bucketName, List<String> idParts) {
-        try {
-            Bucket bucket = storage.getBucket(bucketName);
-            if (!bucket.exists()) {
-                UserContext.message(Message.error("Bucket does not exist."));
-                webContext.respondWith().redirectTemporarily("/ui");
-                return;
-            }
-
-            String id = String.join("/", idParts);
-            StoredObject object = bucket.getObject(id);
-            if (!object.exists()) {
-                UserContext.message(Message.error("Object does not exist."));
-                webContext.respondWith().redirectTemporarily("/ui/" + bucket.getEncodedName());
-                return;
-            }
-
-            // handle /ui/[bucket]/[object]?delete
-            if (webContext.hasParameter("delete")) {
-                object.delete();
-
-                UserContext.message(Message.info("Object successfully deleted."));
-                webContext.respondWith().redirectTemporarily("/ui/" + bucket.getEncodedName());
-                return;
-            }
-
-            Response response = webContext.respondWith();
-            for (Map.Entry<Object, Object> entry : object.getProperties().entrySet()) {
-                response.addHeader(entry.getKey().toString(), entry.getValue().toString());
-            }
-            response.file(object.getFile());
-        } catch (Exception e) {
-            webContext.respondWith().error(HttpResponseStatus.BAD_REQUEST, Exceptions.handle(UserContext.LOG, e));
+        Bucket bucket = storage.getBucket(bucketName);
+        if (!bucket.exists()) {
+            UserContext.message(Message.error("Bucket does not exist."));
+            webContext.respondWith().redirectTemporarily("/ui");
+            return;
         }
+
+        String id = String.join("/", idParts);
+        StoredObject object = bucket.getObject(id);
+        if (!object.exists()) {
+            UserContext.message(Message.error("Object does not exist."));
+            webContext.respondWith().redirectTemporarily("/ui/" + bucket.getEncodedName());
+            return;
+        }
+
+        // handle /ui/[bucket]/[object]?delete
+        if (webContext.hasParameter("delete")) {
+            object.delete();
+
+            UserContext.message(Message.info("Object successfully deleted."));
+            webContext.respondWith().redirectTemporarily("/ui/" + bucket.getEncodedName());
+            return;
+        }
+
+        Response response = webContext.respondWith();
+        for (Map.Entry<Object, Object> entry : object.getProperties().entrySet()) {
+            response.addHeader(entry.getKey().toString(), entry.getValue().toString());
+        }
+        response.file(object.getFile());
     }
 }

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -388,7 +388,7 @@ public class S3Dispatcher implements WebDispatcher {
                 out.beginObject(RESPONSE_BUCKET);
                 out.property("Name", bucket.getName());
                 out.property("CreationDate",
-                             ISO8601_INSTANT.format(Instant.ofEpochMilli(bucket.getFile().lastModified())));
+                             ISO8601_INSTANT.format(Instant.ofEpochMilli(bucket.getFolder().lastModified())));
                 out.endObject();
             }
             out.endObject();

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -99,7 +99,7 @@ public class Storage {
     public List<Bucket> getBuckets() {
         List<Bucket> result = Lists.newArrayList();
         for (File file : Objects.requireNonNull(getBaseDir().listFiles())) {
-            if (file.isDirectory()) {
+            if (file.isDirectory() && Bucket.isValidName(file.getName())) {
                 result.add(new Bucket(file));
             }
         }

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -123,7 +123,7 @@ public class Storage {
         if (!Bucket.isValidName(name)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
-                                    "Bucket name \"%s\" does not adhere to the naming rules. [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html]",
+                                    "Bucket name \"%s\" does not adhere to the rules. [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html]",
                                     name)
                             .handle();
         }

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -17,6 +17,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
 
@@ -106,13 +107,18 @@ public class Storage {
     }
 
     /**
-     * Returns a bucket with the given name
+     * Returns a bucket with the given name.
+     * <p>
+     * The method never returns <b>null</b>, but {@link Bucket#exists()} may return <b>false</b>.
+     * <p>
+     * Make sure that the name passes {@link Bucket#isValidName(String)} by meeting the naming restrictions documented
+     * there.
      *
-     * @param bucket the name of the bucket to fetch. Must not contain .. or / or \
-     * @return the bucket with the given id. Might not exist, but will never be <tt>null</tt>
+     * @param bucket the name of the bucket to fetch
+     * @return the bucket with the given id
      */
-    public Bucket getBucket(String bucket) {
-        if (bucket.contains("..") || bucket.contains("/") || bucket.contains("\\")) {
+    public @Nonnull Bucket getBucket(@Nonnull String bucket) {
+        if (!Bucket.isValidName(bucket)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
                                     "Invalid bucket name: %s. A bucket name must not contain '..' '/' or '\\'",

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -127,6 +127,9 @@ public class Storage {
                                     name)
                             .handle();
         }
+
+        // following the current rules, "ui" is no valid bucket name after all; however, should Amazon change the rules,
+        // this check may apply again
         if (Strings.areEqual(name, "ui")) {
             throw Exceptions.createHandled()
                     .withSystemErrorMessage(
@@ -134,6 +137,7 @@ public class Storage {
                             name)
                     .handle();
         }
+
         return new Bucket(new File(getBaseDir(), name));
     }
 

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -20,6 +20,7 @@ import sirius.kernel.nls.NLS;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Storage service which takes care of organizing buckets on disk.
@@ -97,7 +98,7 @@ public class Storage {
      */
     public List<Bucket> getBuckets() {
         List<Bucket> result = Lists.newArrayList();
-        for (File file : getBaseDir().listFiles()) {
+        for (File file : Objects.requireNonNull(getBaseDir().listFiles())) {
             if (file.isDirectory()) {
                 result.add(new Bucket(file));
             }

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -123,14 +123,14 @@ public class Storage {
         if (!Bucket.isValidName(name)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
-                                    "Invalid bucket name: %s. The name contains illegal characters or is effectively empty.",
+                                    "Bucket name \"%s\" does not adhere to the naming rules. [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html]",
                                     name)
                             .handle();
         }
         if (Strings.areEqual(name, "ui")) {
             throw Exceptions.createHandled()
                     .withSystemErrorMessage(
-                            "Invalid bucket name: %s. The string 'ui' is reserved for internal use.",
+                            "Bucket name \"%s\" is reserved for internal use.",
                             name)
                     .handle();
         }

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -118,11 +118,12 @@ public class Storage {
      * @param name the name of the bucket to fetch
      * @return the bucket with the given name
      */
-    public @Nonnull Bucket getBucket(@Nonnull String name) {
+    @Nonnull
+    public Bucket getBucket(String name) {
         if (!Bucket.isValidName(name)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
-                                    "Invalid bucket name: %s. A bucket name must not contain '..' '/' or '\\'",
+                                    "Invalid bucket name: %s. The name contains illegal characters or is effectively empty.",
                                     name)
                             .handle();
         }

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -157,7 +157,7 @@ public class Storage {
     /**
      * Determines if buckets should be automatically created.
      *
-     * @return <tt>true</tt> if buckets can be auto-created upon the first request
+     * @return <b>true</b> if buckets can be auto-created upon the first request, <b>false</b> else
      */
     public boolean isAutocreateBuckets() {
         return autocreateBuckets;

--- a/src/main/java/ninja/Storage.java
+++ b/src/main/java/ninja/Storage.java
@@ -115,25 +115,25 @@ public class Storage {
      * Make sure that the name passes {@link Bucket#isValidName(String)} by meeting the naming restrictions documented
      * there.
      *
-     * @param bucket the name of the bucket to fetch
-     * @return the bucket with the given id
+     * @param name the name of the bucket to fetch
+     * @return the bucket with the given name
      */
-    public @Nonnull Bucket getBucket(@Nonnull String bucket) {
-        if (!Bucket.isValidName(bucket)) {
+    public @Nonnull Bucket getBucket(@Nonnull String name) {
+        if (!Bucket.isValidName(name)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage(
                                     "Invalid bucket name: %s. A bucket name must not contain '..' '/' or '\\'",
-                                    bucket)
+                                    name)
                             .handle();
         }
-        if (Strings.areEqual(bucket, "ui")) {
+        if (Strings.areEqual(name, "ui")) {
             throw Exceptions.createHandled()
                     .withSystemErrorMessage(
                             "Invalid bucket name: %s. The string 'ui' is reserved for internal use.",
-                            bucket)
+                            name)
                     .handle();
         }
-        return new Bucket(new File(getBaseDir(), bucket));
+        return new Bucket(new File(getBaseDir(), name));
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -110,7 +110,16 @@ public class StoredObject {
      * @return a string representation of the byte-size of the object
      */
     public String getSize() {
-        return NLS.formatSize(file.length());
+        return NLS.formatSize(getSizeBytes());
+    }
+
+    /**
+     * Returns the size of the object in bytes.
+     *
+     * @return the byte-size of the object
+     */
+    public long getSizeBytes() {
+        return file.length();
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -121,6 +121,15 @@ public class StoredObject {
     }
 
     /**
+     * Returns the file used to store the properties and meta headers.
+     *
+     * @return the underlying file used to store the meta infos
+     */
+    public File getPropertiesFile() {
+        return new File(file.getParentFile(), "__ninja_" + file.getName() + ".properties");
+    }
+
+    /**
      * Returns all properties stored along with the object.
      * <p>
      * This is the Content-MD5, Content-Type and any x-amz-meta- header.
@@ -136,15 +145,6 @@ public class StoredObject {
             Exceptions.ignore(e);
         }
         return props;
-    }
-
-    /**
-     * Returns the file used to store the properties and meta headers.
-     *
-     * @return the underlying file used to store the meta infos
-     */
-    public File getPropertiesFile() {
-        return new File(file.getParentFile(), "__ninja_" + file.getName() + ".properties");
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -166,7 +166,7 @@ public class StoredObject {
      * <p>
      * Currently, the key only must not be empty. All UTF-8 characters are valid, but names should be restricted to a
      * subset. See the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html">official naming
-     * rules</a>.
+     * recommendations</a>.
      *
      * @param key the key to check
      * @return <b>true</b> if the key is valid as object key, <b>false</b> else

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -18,8 +18,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -30,15 +28,38 @@ import java.util.Properties;
  * Represents a stored object.
  */
 public class StoredObject {
+
     private final File file;
 
+    private final String name;
+
+    private final String encodedName;
+
     /**
-     * Creates a new StoredObject based on a file.
+     * Creates a new object from the given file.
      *
      * @param file the contents of the object.
      */
     public StoredObject(File file) {
         this.file = file;
+        this.encodedName = file.getName();
+        this.name = decodeKey(this.encodedName);
+
+        if (!Strings.areEqual(this.encodedName, encodeKey(this.name))) {
+            throw Exceptions.createHandled()
+                            .withSystemErrorMessage("File name \"%s\" is not properly encoded.", name)
+                            .handle();
+        }
+    }
+
+    /**
+     * Creates a new object within the given bucket folder and the given key.
+     *
+     * @param folder the bucket's folder
+     * @param key the object's key
+     */
+    public StoredObject(File folder, String key) {
+        this(new File(folder, encodeKey(key)));
     }
 
     /**
@@ -71,7 +92,7 @@ public class StoredObject {
      * @return the name of the object
      */
     public String getName() {
-        return file.getName();
+        return name;
     }
 
     /**
@@ -80,11 +101,7 @@ public class StoredObject {
      * @return the encoded name of the object
      */
     public String getEncodedName() {
-        try {
-            return URLEncoder.encode(getName(), StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            return getName();
-        }
+        return encodedName;
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -20,6 +20,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
@@ -38,6 +39,30 @@ public class StoredObject {
      */
     public StoredObject(File file) {
         this.file = file;
+    }
+
+    /**
+     * Encodes an object key for use as file name.
+     *
+     * @param key the key to encode
+     * @return the encoded key
+     */
+    public static String encodeKey(String key) {
+        return Strings.urlEncode(key).replace("+", "%20");
+    }
+
+    /**
+     * Decodes an encoded object key.
+     *
+     * @param key the key to decode
+     * @return the decoded key
+     */
+    public static String decodeKey(String key) {
+        try {
+            return URLDecoder.decode(key, StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            throw Exceptions.handle(Storage.LOG, e);
+        }
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -127,7 +127,7 @@ public class StoredObject {
      * @return the underlying file used to store the meta infos
      */
     public File getPropertiesFile() {
-        return new File(file.getParentFile(), "__ninja_" + file.getName() + ".properties");
+        return new File(file.getParentFile(), "$" + file.getName() + ".properties");
     }
 
     /**

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -8,9 +8,11 @@
 
 package ninja;
 
+import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -157,5 +159,19 @@ public class StoredObject {
         try (FileOutputStream out = new FileOutputStream(getPropertiesFile())) {
             props.store(out, "");
         }
+    }
+
+    /**
+     * Checks whether the given string is valid for use as object key.
+     * <p>
+     * Currently, the key only must not be empty. All UTF-8 characters are valid, but names should be restricted to a
+     * subset. See the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html">official naming
+     * rules</a>.
+     *
+     * @param key the key to check
+     * @return <b>true</b> if the key is valid as object key, <b>false</b> else
+     */
+    public static boolean isValidKey(@Nullable String key) {
+        return Strings.isFilled(key);
     }
 }

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -8,6 +8,7 @@
 
 package ninja;
 
+import com.google.common.collect.Maps;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
@@ -130,30 +131,39 @@ public class StoredObject {
     }
 
     /**
-     * Returns all properties stored along with the object.
+     * Returns all meta information stored along with the object.
      * <p>
-     * This is the Content-MD5, Content-Type and any x-amz-meta- header.
+     * This is the <tt>Content-MD5</tt>, <tt>Content-Type</tt> and any <tt>x-amz-meta-*</tt> header.
+     * <p>
+     * Internally, a {@link Properties} file is loaded from disk and converted to a {@link Map}.
      *
-     * @return a set of name value pairs representing all properties stored for this object or an empty set if no
+     * @return a set of name value pairs representing all properties stored for this object, or an empty set if no
      * properties could be read
      */
-    public Properties getProperties() {
+    public Map<String, String> getProperties() {
+        // read properties object from disk
         Properties props = new Properties();
         try (FileInputStream in = new FileInputStream(getPropertiesFile())) {
             props.load(in);
         } catch (IOException e) {
             Exceptions.ignore(e);
         }
-        return props;
+
+        // convert the properties object to a string-to-string-map
+        Map<String, String> map = Maps.newTreeMap();
+        props.forEach((key, value) -> map.put(String.valueOf(key), String.valueOf(value)));
+        return map;
     }
 
     /**
-     * Stores the given meta infos for the stored object.
+     * Stores the given meta information for this object.
+     * <p>
+     * Internally, the map is transformed to a {@link Properties} object and stored to disk.
      *
-     * @param properties properties to store
+     * @param properties the properties to store
      * @throws IOException in case of an IO error
      */
-    public void storeProperties(Map<String, String> properties) throws IOException {
+    public void setProperties(Map<String, String> properties) throws IOException {
         Properties props = new Properties();
         properties.forEach(props::setProperty);
         try (FileOutputStream out = new FileOutputStream(getPropertiesFile())) {

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -69,7 +69,7 @@ public class StoredObject {
     }
 
     /**
-     * Returns the last modified date of the object
+     * Returns the object's date of last modification.
      *
      * @return a string representation of the last modification date
      */
@@ -77,12 +77,17 @@ public class StoredObject {
         return NLS.toUserString(getLastModifiedInstant());
     }
 
+    /**
+     * Returns the object's date of last modification.
+     *
+     * @return the last modification date as {@link Instant}
+     */
     public Instant getLastModifiedInstant() {
         return Instant.ofEpochMilli(file.lastModified());
     }
 
     /**
-     * Deletes the object
+     * Deletes the object.
      */
     public void delete() {
         if (!file.delete()) {
@@ -96,7 +101,7 @@ public class StoredObject {
     }
 
     /**
-     * Returns the underlying file
+     * Returns the underlying file.
      *
      * @return the underlying file containing the stored contents
      */
@@ -105,9 +110,9 @@ public class StoredObject {
     }
 
     /**
-     * Determins if the object exists
+     * Determines if the object exists.
      *
-     * @return <tt>true</tt> if the object exists, <tt>false</tt> otherwise
+     * @return <b>true</b> if the object exists, <b>false</b> else
      */
     public boolean exists() {
         return file.exists();
@@ -117,10 +122,9 @@ public class StoredObject {
      * Returns all properties stored along with the object.
      * <p>
      * This is the Content-MD5, Content-Type and any x-amz-meta- header.
-     * </p>
      *
      * @return a set of name value pairs representing all properties stored for this object or an empty set if no
-     * properties could be read.
+     * properties could be read
      */
     public Properties getProperties() {
         Properties props = new Properties();

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -31,9 +31,9 @@ public class StoredObject {
 
     private final File file;
 
-    private final String name;
+    private final String key;
 
-    private final String encodedName;
+    private final String encodedKey;
 
     /**
      * Creates a new object from the given file.
@@ -42,12 +42,12 @@ public class StoredObject {
      */
     public StoredObject(File file) {
         this.file = file;
-        this.encodedName = file.getName();
-        this.name = decodeKey(this.encodedName);
+        this.encodedKey = file.getName();
+        this.key = decodeKey(this.encodedKey);
 
-        if (!Strings.areEqual(this.encodedName, encodeKey(this.name))) {
+        if (!Strings.areEqual(this.encodedKey, encodeKey(this.key))) {
             throw Exceptions.createHandled()
-                            .withSystemErrorMessage("File name \"%s\" is not properly encoded.", name)
+                            .withSystemErrorMessage("File name \"%s\" is not properly encoded.", key)
                             .handle();
         }
     }
@@ -91,8 +91,8 @@ public class StoredObject {
      *
      * @return the name of the object
      */
-    public String getName() {
-        return name;
+    public String getKey() {
+        return key;
     }
 
     /**
@@ -100,8 +100,8 @@ public class StoredObject {
      *
      * @return the encoded name of the object
      */
-    public String getEncodedName() {
-        return encodedName;
+    public String getEncodedKey() {
+        return encodedKey;
     }
 
     /**
@@ -136,12 +136,12 @@ public class StoredObject {
      */
     public void delete() {
         if (!file.delete()) {
-            Storage.LOG.WARN("Failed to delete data file for object %s (%s).", getName(), file.getAbsolutePath());
+            Storage.LOG.WARN("Failed to delete data file for object %s (%s).", getKey(), file.getAbsolutePath());
         }
         if (!getPropertiesFile().delete()) {
             Storage.LOG.WARN("Failed to delete properties file for object %s (%s).",
-                    getName(),
-                    getPropertiesFile().getAbsolutePath());
+                             getKey(),
+                             getPropertiesFile().getAbsolutePath());
         }
     }
 

--- a/src/main/java/ninja/errors/S3ErrorSynthesizer.java
+++ b/src/main/java/ninja/errors/S3ErrorSynthesizer.java
@@ -26,20 +26,19 @@ public class S3ErrorSynthesizer {
     /**
      * Synthesizes an error response.
      *
-     * @param ctx the request to process.
-     * @param bucket the requested bucket, potentially <b>null</b>.
-     * @param key the requested object's key, potentially <b>null</b>.
-     * @param code the error code to send.
-     * @param message a human-readable description of the error.
+     * @param ctx     the request to process
+     * @param bucket  the requested bucket, potentially <b>null</b>
+     * @param key     the requested object's key, potentially <b>null</b>
+     * @param code    the error code to send
+     * @param message a human-readable description of the error
      */
     public void synthesiseError(@Nonnull WebContext ctx,
                                 @Nullable String bucket,
                                 @Nullable String key,
                                 @Nonnull S3ErrorCode code,
                                 @Nullable String message) {
-        XMLStructuredOutput
-                xml = new XMLStructuredOutput(ctx.respondWith()
-                                                 .outputStream(code.getHttpStatusCode(), "text/xml"));
+        XMLStructuredOutput xml =
+                new XMLStructuredOutput(ctx.respondWith().outputStream(code.getHttpStatusCode(), "text/xml"));
 
         String resource = null;
         if (Strings.isFilled(bucket)) {

--- a/src/main/resources/templates/bucket.html.pasta
+++ b/src/main/resources/templates/bucket.html.pasta
@@ -36,7 +36,7 @@
                 <i:for type="ninja.StoredObject" var="obj" items="page.getItems()">
                     <tr>
                         <td>
-                            <a class="link" href="/ui/@bucket.getEncodedName()/@obj.getEncodedName()?noAuth=true">@obj.getName()</a><br/>
+                            <a class="link" href="/ui/@bucket.getEncodedName()/@obj.getEncodedName()">@obj.getName()</a><br/>
                             <span class="muted">@obj.getSize()</span>
                             <span class="muted pull-right">@obj.getLastModified()</span>
                         </td>

--- a/src/main/resources/templates/bucket.html.pasta
+++ b/src/main/resources/templates/bucket.html.pasta
@@ -36,12 +36,12 @@
                 <i:for type="ninja.StoredObject" var="obj" items="page.getItems()">
                     <tr>
                         <td>
-                            <a class="link" href="/ui/@bucket.getEncodedName()/@obj.getEncodedName()">@obj.getName()</a><br/>
+                            <a class="link" href="/ui/@bucket.getEncodedName()/@obj.getEncodedKey()">@obj.getKey()</a><br/>
                             <span class="muted">@obj.getSize()</span>
                             <span class="muted pull-right">@obj.getLastModified()</span>
                         </td>
                         <td class="align-center col-md-2">
-                            <w:deleteLink url="@apply('/ui/%s/%s?delete', bucket.getEncodedName(), obj.getEncodedName())"/>
+                            <w:deleteLink url="@apply('/ui/%s/%s?delete', bucket.getEncodedName(), obj.getEncodedKey())"/>
                         </td>
                     </tr>
                 </i:for>

--- a/src/main/resources/templates/index.html.pasta
+++ b/src/main/resources/templates/index.html.pasta
@@ -49,12 +49,10 @@
                                 }
 
                                 // make sure we have a proper name
+                                // https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
                                 const name = textfield.value;
                                 if (!name || name.trim() !== name
-                                          || name.indexOf('/') >= 0
-                                          || name.indexOf('\\') >= 0
-                                          || name.indexOf('..') >= 0
-                                          || name === '.') {
+                                          || !/^[a-z\d][a-z\d\-.]{1,61}[a-z\d]$/.test(name)) {
                                     reject(name);
                                 }
 

--- a/src/test/java/AWS4SignerAWSSpec.groovy
+++ b/src/test/java/AWS4SignerAWSSpec.groovy
@@ -6,7 +6,6 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials

--- a/src/test/java/AWS4SignerWithPathSuffixAWSSpec.groovy
+++ b/src/test/java/AWS4SignerWithPathSuffixAWSSpec.groovy
@@ -6,7 +6,6 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials

--- a/src/test/java/BaseAWSSpec.groovy
+++ b/src/test/java/BaseAWSSpec.groovy
@@ -5,6 +5,7 @@
  * Copyright by scireum GmbH
  * http://www.scireum.de - info@scireum.de
  */
+
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.AmazonS3Exception

--- a/src/test/java/KeyEncodingSpec.groovy
+++ b/src/test/java/KeyEncodingSpec.groovy
@@ -1,0 +1,31 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+import ninja.StoredObject
+import sirius.kernel.BaseSpecification
+
+class KeyEncodingSpec extends BaseSpecification {
+
+    def "key encoding and decoding works"() {
+        when:
+        String encoded = StoredObject.encodeKey(key)
+        and:
+        String decoded = StoredObject.decodeKey(encoded)
+        then:
+        encoded == encodedKey
+        decoded == key
+        where:
+        key                                                             | encodedKey
+        "simple_key"                                                    | "simple_key"
+        "this/is/one/heck/of/a/complicated/key😛"                       | "this%2Fis%2Fone%2Fheck%2Fof%2Fa%2Fcomplicated%2Fkey%F0%9F%98%9B"
+        "\$\$\$ to make!!!"                                             | "%24%24%24%20to%20make%21%21%21"
+        "🧐🧝‍♂️🧑🏿‍🚀"                                                       | "%F0%9F%A7%90%F0%9F%A7%9D%E2%80%8D%E2%99%82%EF%B8%8F%F0%9F%A7%91%F0%9F%8F%BF%E2%80%8D%F0%9F%9A%80"
+        "\"Was geht?\" fragte der Fuchs, Pfeffer und Salz 'erbei'olend" | "%22Was%20geht%3F%22%20fragte%20der%20Fuchs%2C%20Pfeffer%20und%20Salz%20%27erbei%27olend"
+    }
+
+}

--- a/src/test/java/S3SignerAWSSpec.groovy
+++ b/src/test/java/S3SignerAWSSpec.groovy
@@ -6,7 +6,6 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials

--- a/src/test/java/S3SignerWithPathSuffixAWSSpec.groovy
+++ b/src/test/java/S3SignerWithPathSuffixAWSSpec.groovy
@@ -6,7 +6,6 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials


### PR DESCRIPTION
> https://scireum.myjetbrains.com/youtrack/issue/MISC-11

- Adds support for arbitrary object keys, including slashes
  - This is achieved by URL-encoding object file names
    - Simple keys without special characters remain the same
  - Properties files and markers receive a new collision-free prefix `$` (instead of `__ninja_`)
    - The character `$` will be encoded when used in object keys
  - The required migration of the stored files is done on the fly, on the first access to the bucket
- Centralises checking of bucket names and object keys
  - [Official rules for bucket names](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) are now strictly enforced
- Fixes and revises documentation comments

Closes #144.

## Screenshots

### Web UI

<img width="1405" alt="Screenshot 2020-12-24 at 02 11 10" src="https://user-images.githubusercontent.com/36069303/103047982-74f74700-458d-11eb-808d-faaae798086f.png">

### Local Storage

![Screenshot 2020-12-24 at 02 12 50](https://user-images.githubusercontent.com/36069303/103048018-95270600-458d-11eb-8098-6ab9ac214a4b.png)

![Screenshot 2020-12-24 at 02 15 08](https://user-images.githubusercontent.com/36069303/103048169-fa7af700-458d-11eb-93f9-b9195a6e5e7b.png)


### `s3cmd`

![Screenshot 2020-12-24 at 02 14 29](https://user-images.githubusercontent.com/36069303/103048162-f5b64300-458d-11eb-80d1-642452db6af0.png)
