### PR TITLE
Wrong Signature Error Message (MISC-49)

### DIFF
--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -589,10 +589,11 @@ public class S3Dispatcher implements WebDispatcher {
                 errorSynthesizer.synthesiseError(webContext,
                                                  bucket.getName(),
                                                  key,
-                                                 S3ErrorCode.BadDigest,
-                                                 Strings.apply("Invalid Hash (Expected: %s, Found: %s)",
-                                                               expectedHash,
-                                                               hash));
+                                                 S3ErrorCode.SignatureDoesNotMatch,
+                                                 Strings.apply(
+                                                         "The computed request signature does not match the one provided. Check login credentials. (Expected: %s, Found: %s)",
+                                                         expectedHash,
+                                                         hash));
                 log.log(webContext.getRequest().method().name(),
                         webContext.getRequestedURI(),
                         APILog.Result.REJECTED,

--- a/src/main/java/ninja/errors/S3ErrorCode.java
+++ b/src/main/java/ninja/errors/S3ErrorCode.java
@@ -20,7 +20,7 @@ public enum S3ErrorCode {
     InvalidDigest(HttpResponseStatus.BAD_REQUEST), InvalidRequest(HttpResponseStatus.BAD_REQUEST),
     NoSuchBucket(HttpResponseStatus.NOT_FOUND), NoSuchBucketPolicy(HttpResponseStatus.NOT_FOUND),
     NoSuchKey(HttpResponseStatus.NOT_FOUND), NoSuchLifecycleConfiguration(HttpResponseStatus.NOT_FOUND),
-    NoSuchUpload(HttpResponseStatus.NOT_FOUND);
+    NoSuchUpload(HttpResponseStatus.NOT_FOUND), SignatureDoesNotMatch(HttpResponseStatus.FORBIDDEN);
 
     private final HttpResponseStatus httpStatusCode;
 


### PR DESCRIPTION
- Sends `SignatureDoesNotMatch` (403 Forbidden) instead of `BadDigest` (400 Bad Request) error on wrong
- Improves error message to facilitate debugging

Closes #186.