### PR TITLE
Adds "proxy" functionality to s3ninja.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>1.11.1034</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ninja/AwsUpstream.java
+++ b/src/main/java/ninja/AwsUpstream.java
@@ -1,0 +1,145 @@
+package ninja;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import org.apache.logging.log4j.util.Strings;
+import sirius.kernel.di.std.ConfigValue;
+import sirius.kernel.di.std.Register;
+
+import java.net.URL;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Represents an upstream S3 instance which can be used in case an object is not found locally.
+ *
+ * <br>To enable this functionality the ConfigValue defined in this class must be set accordingly.
+ * <br>The minimal required fields are:<ul>
+ *      <li>{@link AwsUpstream#s3EndPoint}</li>
+ *      <li>{@link AwsUpstream#s3AccessKey}</li>
+ *      <li>{@link AwsUpstream#s3SecretKey}</li>
+ * </ul>
+ * For details for the config name and expected value check each defined ConfigValue.
+ */
+@Register(classes = AwsUpstream.class)
+public class AwsUpstream {
+    /**
+     * The secret key to connect to the upstream S3 instance.
+     * When this value is not set, the proxy functionality is not enabled.
+     */
+    @ConfigValue("upstreamAWS.secretKey")
+    private String s3SecretKey;
+
+    /**
+     * The access key to connect to the upstream S3 instance.
+     * When this value is not set, the proxy functionality is not enabled.
+     */
+    @ConfigValue("upstreamAWS.accessKey")
+    private String s3AccessKey;
+
+    /**
+     * The endpoint used to connect to the upstream S3 instance.
+     * When this value is not set, the proxy functionality is not enabled.
+     */
+    @ConfigValue("upstreamAWS.endPoint")
+    private String s3EndPoint;
+
+    /**
+     * The signing region used to connect to the upstream S3 instance.
+     * If not given, the value "EU" is used.
+     */
+    @ConfigValue("upstreamAWS.signingRegion")
+    private String s3SigningRegion;
+
+    /**
+     * The signer type used to connect to the upstream S3 instance.
+     * This config is optional and will be ignored if missing.
+     */
+    @ConfigValue("upstreamAWS.signerType")
+    private String s3SignerType;
+
+    private AmazonS3 client;
+
+    /**
+     * Checks if the (minimum) needed parameter are available to create the client.
+     *
+     * @return true if the minimum required config values are set.
+     */
+    public boolean isConfigured() {
+        return Stream.of(s3EndPoint, s3AccessKey, s3SecretKey).allMatch(Strings::isNotEmpty);
+    }
+
+    /**
+     * Getter for the client instance to connect to the upstream instance.
+     * Creates an instance if needed.
+     *
+     * @return optional with client instance to upstream instance, if configured
+     */
+    public Optional<AmazonS3> getClient() {
+        if (client == null && isConfigured()) {
+            client = createAWSClient();
+        }
+        return Optional.ofNullable(client);
+    }
+
+    private AmazonS3 createAWSClient() {
+        AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials(s3AccessKey, s3SecretKey));
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder
+                .EndpointConfiguration(s3EndPoint, Optional.ofNullable(s3SigningRegion).orElse("EU"));
+        ClientConfiguration config = new ClientConfiguration().withSocketTimeout(60 * 1000 * 5);
+        Optional.ofNullable(s3SignerType).ifPresent(config::withSignerOverride);
+
+        return AmazonS3ClientBuilder.standard()
+                .withClientConfiguration(config)
+                .withPathStyleAccessEnabled(true)
+                .withCredentials(credentialsProvider)
+                .withEndpointConfiguration(endpointConfiguration)
+                .build();
+    }
+
+    /**
+     * Creates the url used to tunnel request to upstream instance.
+     * <br><b>Important: If you do not request the content, the connection must use the method "HEAD"*</b>
+     *
+     * @param bucket from which an object is fetched
+     * @param object which should be fetched
+     * @param requestFile signalized if the content is needed or not
+     * @return an url which can be used to perform the matching request.
+     */
+    public Optional<URL> generateGetObjectURL(Bucket bucket, StoredObject object, boolean requestFile) {
+        if (!isConfigured()) {
+            return Optional.empty();
+        }
+
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket.getName(), object.getKey());
+        if (requestFile) {
+            request.setMethod(HttpMethod.GET);
+        } else {
+            request.setMethod(HttpMethod.HEAD);
+        }
+
+        return getClient().map(c -> c.generatePresignedUrl(request));
+    }
+
+    public void setS3SecretKey(String s3SecretKey) {
+        this.s3SecretKey = s3SecretKey;
+    }
+
+    public void setS3AccessKey(String s3AccessKey) {
+        this.s3AccessKey = s3AccessKey;
+    }
+
+    public void setS3EndPoint(String s3EndPoint) {
+        this.s3EndPoint = s3EndPoint;
+    }
+
+    public void setS3SignerType(String s3SignerType) {
+        this.s3SignerType = s3SignerType;
+    }
+}

--- a/src/main/java/ninja/AwsUpstream.java
+++ b/src/main/java/ninja/AwsUpstream.java
@@ -8,7 +8,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import org.apache.logging.log4j.util.Strings;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
 
@@ -72,7 +72,7 @@ public class AwsUpstream {
      * @return true if the minimum required config values are set.
      */
     public boolean isConfigured() {
-        return Stream.of(s3EndPoint, s3AccessKey, s3SecretKey).allMatch(Strings::isNotEmpty);
+        return Stream.of(s3EndPoint, s3AccessKey, s3SecretKey).allMatch(Strings::isFilled);
     }
 
     /**

--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -643,6 +643,7 @@ public class S3Dispatcher implements WebDispatcher {
                         id,
                         S3ErrorCode.InternalError,
                         Strings.apply("Error while marking file as deleted"));
+                return;
             }
         }
 

--- a/src/main/java/ninja/StoredObject.java
+++ b/src/main/java/ninja/StoredObject.java
@@ -29,6 +29,8 @@ import java.util.Properties;
  */
 public class StoredObject {
 
+    private static final String DELETED_MARKER = "DeletedMarker";
+
     private final File file;
 
     private final String key;
@@ -220,6 +222,26 @@ public class StoredObject {
         try (FileOutputStream out = new FileOutputStream(getPropertiesFile())) {
             props.store(out, "");
         }
+    }
+
+    /**
+     * Checks if the marker for "deleted" is set.
+     * When an object is marked as "deleted" it can not be requested anymore.
+     * @return true if this file is "deleted"
+     */
+    public boolean isMarkedDeleted() {
+        return getProperties().containsKey(DELETED_MARKER);
+    }
+
+    /**
+     * Sets the object as "deleted", all requests onto this object are handled as if it is deleted.
+     * <br><b>This method does not perform an actual delete!<br>To perform an actual delete please check {@link StoredObject#delete} </b>
+     * @throws IOException if the properties could not be updated
+     */
+    public void markDeleted() throws IOException {
+        Map<String, String> fileProperties = getProperties();
+        fileProperties.put(DELETED_MARKER, "true");
+        setProperties(fileProperties);
     }
 
     /**

--- a/src/test/java/S3ProxySpec.groovy
+++ b/src/test/java/S3ProxySpec.groovy
@@ -1,0 +1,205 @@
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import ninja.AwsUpstream
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import sirius.kernel.di.Injector
+
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+
+class S3ProxySpec extends BaseAWSSpec {
+
+    private static Process upstreamS3Ninja
+
+    private static AwsUpstream awsUpstream
+
+    private static AmazonS3Client upstreamClient
+
+    private static final def port = 10000
+    private static final def secretKey = "AKIAIOSFODNN7EXAMPLE" + new Random().nextInt()
+    private static final def accessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" + new Random().nextInt()
+    private static final def endPoint = "http://localhost:" + port + "/s3"
+    private static final def signerType = "S3SignerType"
+    private static final def storage = File.createTempDir("s3-test-upstream-instance", "")
+
+    private static final def bucketName = "proxy-test"
+
+    @Override
+    AmazonS3Client getClient() {
+        return createClient("AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "http://localhost:9999/s3")
+    }
+
+    static
+    AmazonS3Client createClient(accessKey, secretKey, endpoint) {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey)
+        AmazonS3Client newClient = new AmazonS3Client(credentials, new ClientConfiguration().withSignerOverride("S3SignerType"))
+        newClient.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build())
+        newClient.setEndpoint(endpoint)
+        return newClient
+    }
+
+    @BeforeClass
+    static
+    def "Start 'upstream' instance"() {
+        upstreamClient = createClient(accessKey, secretKey, endPoint)
+        awsUpstream = Injector.context().getPart(AwsUpstream)
+        awsUpstream.s3SecretKey = secretKey
+        awsUpstream.s3AccessKey = accessKey
+        awsUpstream.s3EndPoint = endPoint
+        awsUpstream.s3SignerType = signerType
+
+        Assert.assertTrue(awsUpstream.isConfigured())
+        println "Init 'upstream' s3-ninja"
+
+        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java"
+        String classpath = System.getProperty("java.class.path")
+        ProcessBuilder builder = new ProcessBuilder(javaBin, "-cp", classpath, "sirius.kernel.Setup")
+        builder.environment().put("http.port", String.valueOf(port))
+        builder.environment().put("storage.awsAccessKey", accessKey)
+        builder.environment().put("storage.awsSecretKey", secretKey)
+        builder.environment().put("storage.baseDir", storage.absolutePath)
+        upstreamS3Ninja = builder.start()
+
+        boolean waitForServer = true
+        def waitServerTimeout = LocalDateTime.now().plusSeconds(10)
+        while (waitForServer && waitServerTimeout.isAfter(LocalDateTime.now())) {
+            try {
+                upstreamClient.doesBucketExist(bucketName)
+                waitForServer = false
+            } catch (Throwable ignored) {
+                println "Waiting for 'upstream' s3-ninja to come online"
+                sleep(100)
+            }
+        }
+        Assert.assertFalse("Wait for 'upstream' s3-ninja timed out", waitForServer)
+        if (upstreamS3Ninja.isAlive()) {
+            println "Started 'upstream' s3-ninja, storage dir: " + storage.absolutePath
+        } else {
+            println "'upstream' s3-ninja exited prematurely, exit code: " + upstreamS3Ninja.exitValue()
+        }
+        Assert.assertTrue(upstreamS3Ninja.isAlive())
+    }
+
+    @AfterClass
+    static
+    def "Stop 'upstream' instance"() {
+        awsUpstream.s3SecretKey = null
+        awsUpstream.s3AccessKey = null
+        awsUpstream.s3EndPoint = null
+        awsUpstream.s3SignerType = null
+        if (upstreamS3Ninja != null) {
+            upstreamS3Ninja.destroy()
+            println "'upstream' s3-ninja exited stopped: " + upstreamS3Ninja.waitFor(1, TimeUnit.MINUTES)
+        }
+    }
+
+    def "Object exists neither local or remote"() {
+        given:
+        def objectName = "missing-object"
+        expect:
+        !upstreamClient.doesObjectExist(bucketName, objectName)
+        !client.doesObjectExist(bucketName, objectName)
+    }
+
+    def "Get upstream only object"() {
+        given:
+        def objectName = "upstream-only-object"
+        def content = "This does now exist."
+        when:
+        upstreamClient.deleteObject(bucketName, objectName)
+        then:
+        !upstreamClient.doesObjectExist(bucketName, objectName)
+        !client.doesObjectExist(bucketName, objectName)
+        when:
+        upstreamClient.putObject(bucketName, objectName, content)
+        then:
+        upstreamClient.doesObjectExist(bucketName, objectName)
+        client.doesObjectExist(bucketName, objectName)
+        content == client.getObjectAsString(bucketName, objectName)
+    }
+
+    def "Delete locally only, upstream must be untouched"() {
+        given:
+        def objectName = "delete-only-locally"
+        def upstreamContent = "This does now exist. Upstream"
+        when:
+        // cleanup existing files
+        upstreamClient.deleteObject(bucketName, objectName)
+        client.deleteObject(bucketName, objectName)
+
+        upstreamClient.putObject(bucketName, objectName, upstreamContent)
+        then:
+        upstreamContent == client.getObjectAsString(bucketName, objectName)
+        when:
+        client.deleteObject(bucketName, objectName)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        !client.doesObjectExist(bucketName, objectName)
+    }
+
+    def "Overwrite locally only, upstream must be untouched"() {
+        given:
+        def objectName = "overwrite-locally"
+        def upstreamContent = "This does now exist. Upstream"
+        def localContent = "This does now exist. Locally"
+        when:
+        // cleanup existing files
+        upstreamClient.deleteObject(bucketName, objectName)
+        client.deleteObject(bucketName, objectName)
+
+        upstreamClient.putObject(bucketName, objectName, upstreamContent)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        upstreamContent == client.getObjectAsString(bucketName, objectName)
+        when:
+        client.putObject(bucketName, objectName, localContent)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        localContent == client.getObjectAsString(bucketName, objectName)
+    }
+
+    def "Locally only object"() {
+        given:
+        def objectName = "exists-only-locally"
+        def localContent = "This does now exist. Locally"
+        when:
+        client.putObject(bucketName, objectName, localContent)
+        then:
+        !upstreamClient.doesObjectExist(bucketName, objectName)
+        localContent == client.getObjectAsString(bucketName, objectName)
+    }
+
+
+    def "Overwrite locally deleted file"() {
+        given:
+        def objectName = "overwrite-locally-deleted"
+        def upstreamContent = "This does now exist. Upstream"
+        def localContent = "This does now exist. Locally"
+        when:
+        // cleanup existing files
+        upstreamClient.deleteObject(bucketName, objectName)
+        client.deleteObject(bucketName, objectName)
+
+        upstreamClient.putObject(bucketName, objectName, upstreamContent)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        upstreamContent == client.getObjectAsString(bucketName, objectName)
+        when:
+        client.deleteObject(bucketName, objectName)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        !client.doesObjectExist(bucketName, objectName)
+        when:
+        client.putObject(bucketName, objectName, localContent)
+        then:
+        upstreamContent == upstreamClient.getObjectAsString(bucketName, objectName)
+        localContent == client.getObjectAsString(bucketName, objectName)
+    }
+}


### PR DESCRIPTION
An upstream s3 instance can be configured.

If configured all fetching requests, which can not be satisfied with by the s3-ninja itself, will internally be requested from the upstream instance.

Put and Delete operations are only performed on the s3ninja and will never be send to the upstream instance.