### PR TITLE
Fix CopyObject for CopySource containing a key with slashes

### DIFF
--- a/src/main/java/ninja/S3Dispatcher.java
+++ b/src/main/java/ninja/S3Dispatcher.java
@@ -734,8 +734,8 @@ public class S3Dispatcher implements WebDispatcher {
                               String.format("Source '%s' must contain '/'", copy));
             return;
         }
-        String srcBucketName = copy.substring(1, copy.lastIndexOf(PATH_DELIMITER));
-        String srcId = copy.substring(copy.lastIndexOf(PATH_DELIMITER) + 1);
+        String srcBucketName = copy.substring(1, copy.indexOf(PATH_DELIMITER, 1));
+        String srcId = copy.substring(copy.indexOf(PATH_DELIMITER, 1) + 1);
         Bucket srcBucket = storage.getBucket(srcBucketName);
         if (!srcBucket.exists()) {
             signalObjectError(webContext,


### PR DESCRIPTION
When attempting to use CopyObject with a CopySource key containing slashes such as bar/baz/mypic.jpg S3Ninja returns an error:

"sirius.kernel.health.HandledException: An error occurred: Bucket name "mybucket/bar/baz"; does not adhere to the rules.
[https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html]"

The problem is that S3Dispatcher's copyObject() doesn't correctly parse the bucket name and key from `x-amz-copy-source` as `copy.lastIndexOf(PATH_DELIMITER)` returns the index of the last separator in the key, rather than the index of first separator after the bucket name.
