### PR TITLE
Fix: UI Downloads

### DIFF
--- a/src/main/java/ninja/NinjaController.java
+++ b/src/main/java/ninja/NinjaController.java
@@ -296,7 +296,7 @@ public class NinjaController extends BasicController {
             return;
         }
 
-        Response response = webContext.respondWith();
+        Response response = webContext.respondWith().named(object.getKey());
         for (Map.Entry<String, String> entry : object.getProperties().entrySet()) {
             response.addHeader(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
When downloading a file via the UI, the key should be used as filename.

Closes #207.
