### PR TITLE
Bugfix: Parsing of Trailing Headers

### DIFF
--- a/src/main/java/ninja/SignedChunkHandler.java
+++ b/src/main/java/ninja/SignedChunkHandler.java
@@ -64,7 +64,8 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
 
     /**
      * Extracts all complete chunks from {@link #chunkBuffer} and returns a flag indicating whether the entire transfer
-     * is complete. The latter case is given when receiving a zero-length chunk.
+     * is complete. A zero-length chunk completes the data portion, but trailer-capable requests may still have trailing
+     * headers to consume before the transfer is finished.
      *
      * @return flag indicating whether the transfer is complete. If <b>false</b>, continue to invoke the method after
      * more data has been received.
@@ -78,7 +79,7 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
             int sizeOfChunk = transferNextChunk();
 
             if (sizeOfChunk == 0) {
-                // we have read the last chunk and completed the transfer hence
+                // The last data chunk has been read; trailer-capable requests can still send trailing headers.
                 if (expectsTrailingHeaders()) {
                     readingTrailingHeaders = true;
                     return tryToCompleteTrailingHeaders();
@@ -161,6 +162,12 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
         return TRAILING_HEADER_MARKERS.contains(contentSHA256Header);
     }
 
+    /**
+     * Consumes trailing headers after the final zero-length chunk. These headers may be split across network reads, so
+     * an incomplete line keeps the handler in trailer mode until more data arrives.
+     *
+     * @return <tt>true</tt> if the blank trailer terminator has been consumed, <tt>false</tt> if more data is needed.
+     */
     private boolean tryToCompleteTrailingHeaders() {
         while (true) {
             chunkBuffer.markReaderIndex();
@@ -256,6 +263,12 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
         return readRawLine(content).filter(Strings::isFilled);
     }
 
+    /**
+     * Reads a CRLF-terminated line from the buffer.
+     *
+     * @param content the buffer to read from.
+     * @return an optional containing the line without CRLF, or an empty optional if the line is incomplete.
+     */
     private Optional<String> readRawLine(ByteBuf content) {
         StringBuilder signatureString = new StringBuilder();
         boolean previousWasCR = false;

--- a/src/main/java/ninja/SignedChunkHandler.java
+++ b/src/main/java/ninja/SignedChunkHandler.java
@@ -16,8 +16,6 @@ import sirius.web.http.WebContext;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -42,6 +40,8 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
     private final ByteBuf chunkBuffer = Unpooled.buffer();
 
     private final WebContext webContext;
+
+    private boolean readingTrailingHeaders;
 
     SignedChunkHandler(@Nullable WebContext webContext) {
         this.webContext = webContext;
@@ -70,12 +70,21 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
      * more data has been received.
      */
     private boolean tryToCompleteTransfer() throws IOException {
+        if (readingTrailingHeaders) {
+            return tryToCompleteTrailingHeaders();
+        }
+
         while (true) {
             int sizeOfChunk = transferNextChunk();
 
             if (sizeOfChunk == 0) {
                 // we have read the last chunk and completed the transfer hence
-                readTrailingHeaders();
+                if (expectsTrailingHeaders()) {
+                    readingTrailingHeaders = true;
+                    return tryToCompleteTrailingHeaders();
+                }
+
+                skipOptionalEmptyTrailingLine();
                 return true;
             } else if (sizeOfChunk < 0) {
                 // the last chunk could not be read entirely, we need more data
@@ -146,24 +155,32 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
         super.handle(Unpooled.EMPTY_BUFFER, true);
     }
 
-    private void readTrailingHeaders() {
+    private boolean expectsTrailingHeaders() {
         String contentSHA256Header =
                 Optional.ofNullable(webContext).map(context -> context.getHeader("x-amz-content-sha256")).orElse("");
-        if (TRAILING_HEADER_MARKERS.contains(contentSHA256Header)) {
-            List<String> trailingHeaders = new ArrayList<>();
-            while (true) {
-                Optional<String> header = readRawSignature(chunkBuffer);
-                if (header.isEmpty() || Strings.isEmpty(header.get())) {
-                    break;
-                }
-                trailingHeaders.add(header.get());
+        return TRAILING_HEADER_MARKERS.contains(contentSHA256Header);
+    }
 
-                // note that for now, we don't do anything with the trailing headers; we could check the signature here
+    private boolean tryToCompleteTrailingHeaders() {
+        while (true) {
+            chunkBuffer.markReaderIndex();
+            Optional<String> header = readRawLine(chunkBuffer);
+            if (header.isEmpty()) {
+                chunkBuffer.resetReaderIndex();
+                return false;
             }
 
-            return;
-        }
+            if (Strings.isEmpty(header.get())) {
+                readingTrailingHeaders = false;
+                chunkBuffer.discardReadBytes();
+                return true;
+            }
 
+            // Note that for now, we don't do anything with the trailing headers; we could check the signature here.
+        }
+    }
+
+    private void skipOptionalEmptyTrailingLine() {
         if (chunkBuffer.readableBytes() >= 2) {
             byte supposedCR = chunkBuffer.getByte(0);
             byte supposedLF = chunkBuffer.getByte(1);
@@ -236,21 +253,29 @@ class SignedChunkHandler extends sirius.web.http.InputStreamHandler {
      * @return an optional containing the raw chunk signature string.
      */
     private Optional<String> readRawSignature(ByteBuf content) {
+        return readRawLine(content).filter(Strings::isFilled);
+    }
+
+    private Optional<String> readRawLine(ByteBuf content) {
         StringBuilder signatureString = new StringBuilder();
         boolean previousWasCR = false;
         while (content.isReadable()) {
             byte data = content.readByte();
-            if (data == CARRIAGE_RETURN_CHARACTER) {
-                previousWasCR = true;
-            } else if (previousWasCR && data == LINE_FEED_CHARACTER) {
-                // extract the string, skipping the trailing <CR> character
-                return Optional.of(signatureString.substring(0, signatureString.length() - 1))
-                               .filter(Strings::isFilled);
-            } else {
+
+            if (previousWasCR) {
                 previousWasCR = false;
+                if (data == LINE_FEED_CHARACTER) {
+                    return Optional.of(signatureString.toString());
+                }
+
+                signatureString.append(CARRIAGE_RETURN_CHARACTER);
             }
 
-            signatureString.append((char) data);
+            if (data == CARRIAGE_RETURN_CHARACTER) {
+                previousWasCR = true;
+            } else {
+                signatureString.append((char) data);
+            }
         }
 
         // reaching this point, we ran out of data prematurely

--- a/src/test/kotlin/ninja/SignedChunkHandlerTest.kt
+++ b/src/test/kotlin/ninja/SignedChunkHandlerTest.kt
@@ -16,13 +16,15 @@ class SignedChunkHandlerTest {
         every { webContext.getHeader("x-amz-content-sha256") } returns "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
 
         val handler = SignedChunkHandler(webContext)
-        val firstContent = """
-            |5;chunk-signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            |hello
-            |0;chunk-signature=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-            |
-        """.trimMargin().replace("\n", "\r\n")
-        val trailerContent = "x-amz-trailer-signature:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\r\n\r\n"
+        val firstContent = listOf(
+            "5;chunk-signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "hello",
+            "0;chunk-signature=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ).joinToString(separator = "\r\n", postfix = "\r\n")
+        val trailerContent = listOf(
+            "x-amz-trailer-signature:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            ""
+        ).joinToString(separator = "\r\n", postfix = "\r\n")
 
         assertDoesNotThrow {
             handler.handle(Unpooled.copiedBuffer(firstContent, StandardCharsets.UTF_8), false)

--- a/src/test/kotlin/ninja/SignedChunkHandlerTest.kt
+++ b/src/test/kotlin/ninja/SignedChunkHandlerTest.kt
@@ -1,0 +1,32 @@
+package ninja
+
+import io.mockk.every
+import io.mockk.mockk
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import sirius.web.http.WebContext
+import java.nio.charset.StandardCharsets
+
+class SignedChunkHandlerTest {
+
+    @Test
+    fun `split trailer signature after final chunk is accepted`() {
+        val webContext = mockk<WebContext>()
+        every { webContext.getHeader("x-amz-content-sha256") } returns "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+
+        val handler = SignedChunkHandler(webContext)
+        val firstContent = """
+            |5;chunk-signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            |hello
+            |0;chunk-signature=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            |
+        """.trimMargin().replace("\n", "\r\n")
+        val trailerContent = "x-amz-trailer-signature:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\r\n\r\n"
+
+        assertDoesNotThrow {
+            handler.handle(Unpooled.copiedBuffer(firstContent, StandardCharsets.UTF_8), false)
+            handler.handle(Unpooled.copiedBuffer(trailerContent, StandardCharsets.UTF_8), true)
+        }
+    }
+}


### PR DESCRIPTION
Properly parses trailing headers also in more complicated scenarios where content is spread across multiple chunks.

Fixes #358.