### PR TITLE
Migrate to Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>15.3.0</version>
+        <version>16.0.0</version>
     </parent>
 
     <artifactId>s3ninja</artifactId>
@@ -20,8 +20,8 @@
     <properties>
         <build.tag>DEVELOPMENT-SNAPSHOT</build.tag>
 
-        <sirius.kernel>52.1.1</sirius.kernel>
-        <sirius.web>106.2.0</sirius.web>
+        <sirius.kernel>53.0.0</sirius.kernel>
+        <sirius.web>107.0.0</sirius.web>
 
         <!-- Force build to complete with warnings, e.g.: while using deprecated code -->
         <maven.compiler.warnings></maven.compiler.warnings>

--- a/src/main/java/ninja/PresignedPostService.java
+++ b/src/main/java/ninja/PresignedPostService.java
@@ -8,9 +8,9 @@
 
 package ninja;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import com.google.common.io.BaseEncoding;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;

--- a/src/main/java/ninja/S3Policy.java
+++ b/src/main/java/ninja/S3Policy.java
@@ -8,15 +8,15 @@
 
 package ninja;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ArrayNode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sirius.kernel.commons.Value;
 import sirius.web.http.WebContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -316,10 +316,10 @@ public class S3Policy {
         return switch (field) {
             case "bucket" -> bucket.getName();
             case "key" -> key;
-            case "content-length-range" -> webContext.getHeaderValue(HttpHeaderNames.CONTENT_LENGTH).asString("");
+            case "content-length-range" -> webContext.getHeaderValue(HttpHeaderNames.CONTENT_LENGTH).asString();
             case "Content-Type" -> webContext.getHeader("Content-Type");
-            case "success_action_redirect" -> webContext.get("success_action_redirect").asString("");
-            case "success_action_status" -> webContext.get("success_action_status").asString("");
+            case "success_action_redirect" -> webContext.get("success_action_redirect").asString();
+            case "success_action_status" -> webContext.get("success_action_status").asString();
             default -> webContext.get(field).asString("");
         };
     }

--- a/src/main/java/ninja/S3Policy.java
+++ b/src/main/java/ninja/S3Policy.java
@@ -8,9 +8,9 @@
 
 package ninja;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -136,7 +136,7 @@ public class S3Policy {
         try {
             String jsonPolicy = new String(Base64.getDecoder().decode(base64Policy), StandardCharsets.UTF_8);
             this.policyData = MAPPER.readTree(jsonPolicy);
-            this.expiration = Instant.parse(policyData.get("expiration").asText());
+            this.expiration = Instant.parse(policyData.get("expiration").asString(""));
             this.conditions = parseConditions(policyData.get("conditions"));
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid policy document", e);
@@ -174,18 +174,18 @@ public class S3Policy {
             arrayNode.forEach(condition -> {
                 if (condition.isArray()) {
                     Map<String, Object> conditionMap = new HashMap<>();
-                    conditionMap.put("operator", condition.get(0).asText());
-                    String field = condition.get(1).asText();
+                    conditionMap.put("operator", condition.get(0).asString(""));
+                    String field = condition.get(1).asString("");
                     if (field.startsWith("$") && field.length() > 1) {
                         field = field.substring(1); // Remove '$' prefix
                     }
                     conditionMap.put("field", field);
-                    conditionMap.put("value", condition.get(2).asText());
+                    conditionMap.put("value", condition.get(2).asString(""));
                     result.add(conditionMap);
                 } else if (condition.isObject()) {
                     Map<String, Object> conditionMap = new HashMap<>();
                     condition.properties()
-                             .forEach(entry -> conditionMap.put(entry.getKey(), entry.getValue().asText()));
+                             .forEach(entry -> conditionMap.put(entry.getKey(), entry.getValue().asString("")));
                     result.add(conditionMap);
                 }
             });
@@ -316,11 +316,11 @@ public class S3Policy {
         return switch (field) {
             case "bucket" -> bucket.getName();
             case "key" -> key;
-            case "content-length-range" -> webContext.getHeaderValue(HttpHeaderNames.CONTENT_LENGTH).asString();
+            case "content-length-range" -> webContext.getHeaderValue(HttpHeaderNames.CONTENT_LENGTH).asString("");
             case "Content-Type" -> webContext.getHeader("Content-Type");
-            case "success_action_redirect" -> webContext.get("success_action_redirect").asString();
-            case "success_action_status" -> webContext.get("success_action_status").asString();
-            default -> webContext.get(field).asString();
+            case "success_action_redirect" -> webContext.get("success_action_redirect").asString("");
+            case "success_action_status" -> webContext.get("success_action_status").asString("");
+            default -> webContext.get(field).asString("");
         };
     }
 

--- a/src/test/kotlin/CsrfProtectionTest.kt
+++ b/src/test/kotlin/CsrfProtectionTest.kt
@@ -40,7 +40,7 @@ class CsrfProtectionTest {
         val sessionTokenResult = TestRequest.SAFEPOST("/.api/generate-session-token").executeAndBlock()
         assertEquals(HttpResponseStatus.OK, sessionTokenResult.status)
         assertTrue(sessionTokenResult.contentAsJson["success"].asBoolean())
-        assertTrue(sessionTokenResult.contentAsJson["token"].asText().isNotBlank())
+        assertTrue(sessionTokenResult.contentAsJson["token"].asString("").isNotBlank())
 
         val presignedPostResult = TestRequest.SAFEPOST("/.api/generate-presigned-post")
             .withParameter("bucket", "csrf-test")

--- a/src/test/kotlin/PresignedPostGeneratorTest.kt
+++ b/src/test/kotlin/PresignedPostGeneratorTest.kt
@@ -1,10 +1,9 @@
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.io.BaseEncoding
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import sirius.kernel.SiriusExtension
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.ObjectNode
 import java.nio.charset.StandardCharsets
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -136,7 +135,7 @@ class PresignedPostGeneratorTest {
             conditions.add(objectMapper.createObjectNode().put("x-amz-security-token", sessionToken))
         }
 
-        policy.set<ArrayNode>("conditions", conditions)
+        policy.set("conditions", conditions)
         return policy
     }
 
@@ -200,4 +199,3 @@ class PresignedPostGeneratorTest {
         return mac.doFinal(value)
     }
 }
-


### PR DESCRIPTION
### Description

Migrates s3ninja from Jackson 2.22.0 to Jackson 3.2.0 as part of the sirius-wide upgrade (see related PRs).

- Renames all imports from `com.fasterxml.jackson` to the new `tools.jackson` packages; annotations remain on the 2.x line.
- Applies the behavior-preserving accessor replacements documented in the sirius-kernel PR: `asText()` → `asString("")`, retaining the lenient Jackson 2 semantics when parsing presigned POST policies (Jackson 3 accessors throw for missing or mismatching values).
- Updates the parent to 16.0.0 and the sirius dependencies to the released Jackson 3 versions (kernel 53.0.0, web 107.0.0).

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1149](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1149)
- This PR is related to PR: https://github.com/scireum/sirius-parent/pull/79 (see the BREAKING CHANGES overview there)

### Checklist

- [x] Code change has been tested and works locally (full test suite green against the released versions)
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
